### PR TITLE
Added event skimming for data

### DIFF
--- a/NtupleProducer/BToKeeNtupleProducer.cc
+++ b/NtupleProducer/BToKeeNtupleProducer.cc
@@ -332,6 +332,8 @@ int main(int argc, char** argv) {
     }
 
 
+    if(isData && _BToKee_sel_index<0) continue;
+
     
     //Select the BToKee candidate based on gen matching
 

--- a/NtupleProducer/BToKmumuNtupleProducer.cc
+++ b/NtupleProducer/BToKmumuNtupleProducer.cc
@@ -340,6 +340,9 @@ int main(int argc, char** argv) {
 
     //Take as probe muon leading soft ID muon + trigger-matched if BPHParking data
 
+    if(isData && _BToKmumu_sel_index<0) continue;
+
+
     if(_BToKmumu_sel_index>=0){
       
       for(int i_mu=0; i_mu<nMuon; i_mu++){


### PR DESCRIPTION
Added skimming in case of data processing to discard events without valid BToKee or BToKmumu triplet to limit size of ntuples (already 8T for BToKmumu in a single 2018A fill)
Ultimately PFCand branches may need to be made optional also in NanoAOD to save space