### PR TITLE
Add max index check

### DIFF
--- a/NtupleProducer/BToKeeNtupleProducer.cc
+++ b/NtupleProducer/BToKeeNtupleProducer.cc
@@ -216,7 +216,11 @@ int main(int argc, char** argv) {
 
   for (int iEntry = 0; iEntry < nentries ; iEntry++){
 
-    tree->GetEntry(iEntry);
+    int out = tree->GetEntry(iEntry);
+    if(out<0){
+      cout<<"Error retrievieng entry #"<<iEntry<<endl;
+      return -1;
+    }
 
     if(iEntry%10000==0) cout<<"Entry #"<<iEntry<<" "<< int(100*float(iEntry)/nentries)<<"%"<<endl;
 

--- a/NtupleProducer/BToKmumuNtupleProducer.cc
+++ b/NtupleProducer/BToKmumuNtupleProducer.cc
@@ -229,7 +229,11 @@ int main(int argc, char** argv) {
 
   for (int iEntry = 0; iEntry < nentries ; iEntry++){
 
-    tree->GetEntry(iEntry);
+    int out = tree->GetEntry(iEntry);
+    if(out<0){
+      cout<<"Error retrievieng entry #"<<iEntry<<endl;
+      return -1;
+    }
 
     if(iEntry%10000==0) cout<<"Entry #"<<iEntry<<" "<< int(100*float(iEntry)/nentries)<<"%"<<endl;
 

--- a/NtupleProducer/BToKpipiNtupleProducer.cc
+++ b/NtupleProducer/BToKpipiNtupleProducer.cc
@@ -195,7 +195,11 @@ int main(int argc, char** argv) {
 
   for (int iEntry = 0; iEntry < nentries ; iEntry++){
 
-    tree->GetEntry(iEntry);
+    int out = tree->GetEntry(iEntry);
+    if(out<0){
+      cout<<"Error retrievieng entry #"<<iEntry<<endl;
+      return -1;
+    }
 
     if(iEntry%10000==0) cout<<"Entry #"<<iEntry<<" "<< int(100*float(iEntry)/nentries)<<"%"<<endl;
 

--- a/NtupleProducer/NanoAODTree.h
+++ b/NtupleProducer/NanoAODTree.h
@@ -22,8 +22,8 @@
 const int kMuonMax = 100;
 const int kElectronMax = 100;
 const int kBToKpipiMax = 1000000;
-const int kBToKmumuMax = 10000;
-const int kBToKeeMax = 10000;
+const int kBToKmumuMax = 50000;
+const int kBToKeeMax = 50000;
 const int kGenPartMax = 10000;
 const int kTrigObjMax = 1000;
 const int kPFCandMax = 10000;
@@ -349,7 +349,18 @@ void NanoAODTree::Init(TChain* tree)
 Int_t NanoAODTree::GetEntry(int entry)
 {
 
-  return _tree->GetEntry(entry);
+  int out = _tree->GetEntry(entry);
+
+  if(nMuon>kMuonMax) return -1;
+  if(nElectron>kElectronMax) return -1;
+  if(nBToKpipi>kBToKpipiMax) return -1;
+  if(nBToKmumu>kBToKmumuMax) return -1;
+  if(nBToKee>kBToKeeMax) return -1;
+  if(nGenPart>kGenPartMax) return -1;
+  if(nTrigObj>kTrigObjMax)  return -1;
+  if(nPFCand>kPFCandMax) return -1;
+
+  return out;
 
 } 
 


### PR DESCRIPTION
This PR adds an explicit error in case the number of objects in the collection goes beyond the maximum value used to fill additional branches.
Previously, this would have resulted in dummy values filled for the branches created in the ntuple producer for indices beyond the max values.
Also increases kBToKeeMax and kBToKmumuMax to be on the safe side.