### PR TITLE
single file for data and old and new MC tested for Kmumu final state

### DIFF
--- a/NtupleProducer/bin/BToKstllNtupleProducer.cc
+++ b/NtupleProducer/bin/BToKstllNtupleProducer.cc
@@ -1,0 +1,706 @@
+// BToKstllNtupleProducer --isMC (0,1,2) --isResonant (0, 1, -1) --isEleFS (0, 1) --isKstFS (0, 1) --isLT (0, 1) --output ("outfile") --input ("inputFile")
+
+// new features => gen_index refers to the closest in dR, no minimum dR required
+//                 saved branch with dR of gen-reco lep1, lep2, kaon
+//              => for gen_tag_muon do not require minimum pT
+//                 saved branch with highest pT of extra muon (tag candidate)
+//              => matching for reco tag muon is dR < 0.01
+//              => isMC == 2 is for old - Thomas' - MC; isMC == 1 is new; isMC == 0 is DATA 
+// 
+
+#include <iostream>
+#include <fstream>
+#include "TFile.h"
+#include "TTree.h"
+#include "TChain.h"
+#include "TString.h"
+#include "TLorentzVector.h"
+
+#include "NanoAODTree.h"
+
+
+float JPsiMass_ = 3.0969;
+float BuMass_ = 5.279;
+float KaonMass_ = 0.493677;
+float MuonMass_ = 0.10565837;
+float ElectronMass_ = 0.5109989e-3;
+
+
+int main(int argc, char **argv){
+
+  if(argc < 2) {
+    std::cout << " Missing arguments " << std::endl;
+    return -1;
+  }
+  int isMC = -1;
+  int isResonant = -1;
+  int isEleFinalState = -1;
+  int isKstFinalState = -1;
+  int isLeptonTrack = -1;
+  string output = "";
+  string input = "";
+  string listFilesTXT = "";
+  bool inputTXT = false;
+  float genMuPtCut = 8.;
+  bool overwrite = false;
+  for (int i = 1; i < argc; ++i) {
+    if(std::string(argv[i]) == "--isMC") {
+      if (i + 1 < argc) {
+	isMC = atoi(argv[i+1]);
+	break;
+      } else {
+	std::cerr << " --isMC option requires one argument " << std::endl;
+	return 1;
+      }
+    }
+  }for (int i = 1; i < argc; ++i) {
+    if(std::string(argv[i]) == "--isResonant") {
+      if (i + 1 < argc) {
+	isResonant = atoi(argv[i+1]);
+	break;
+      } else {
+	std::cerr << " --isResonant option requires one argument " << std::endl;
+	return 1;
+      }
+    }
+  }for (int i = 1; i < argc; ++i) {
+    if(std::string(argv[i]) == "--isEleFS") {
+      if (i + 1 < argc) {
+	isEleFinalState = atoi(argv[i+1]);
+	break;
+      } else {
+	std::cerr << " --isElFinalState option requires one argument " << std::endl;
+	return 1;
+      }
+    }
+  }for (int i = 1; i < argc; ++i) {
+    if(std::string(argv[i]) == "--isKstFS") {
+      if (i + 1 < argc) {
+	isKstFinalState = atoi(argv[i+1]);
+	break;
+      } else {
+	std::cerr << " --isKstFinalState option requires one argument " << std::endl;
+	return 1;
+      }
+    }
+  }for (int i = 1; i < argc; ++i) {
+    if(std::string(argv[i]) == "--isLT") {
+      if (i + 1 < argc) {
+	isLeptonTrack = atoi(argv[i+1]);
+	break;
+      } else {
+	std::cerr << " --isLeptonTrack option requires one argument " << std::endl;
+	return 1;
+      }
+    }
+  }for (int i = 1; i < argc; ++i) {
+    if(std::string(argv[i]) == "--output") {
+      if (i + 1 < argc) {
+	output = argv[i+1];
+	break;
+      } else {
+	std::cerr << "--output option requires one argument." << std::endl;
+	return 1;
+      }      
+    }  
+  }for (int i = 1; i < argc; ++i) {
+    if(std::string(argv[i]) == "--input") {
+      if (i + 1 < argc) {
+        input = argv[i+1];
+        break;
+      } else {
+	std::cerr << "--intput option requires one argument." << std::endl;
+        return 1;
+      }
+    }
+    else if(std::string(argv[i]) == "--inputTXT") {
+      if (i + 1 < argc) {
+        inputTXT = true;
+        listFilesTXT = argv[i+1];
+        break;
+      } else {
+	std::cerr << "--intputTXT option requires one argument." << std::endl;
+        return 1;
+      }
+    }
+  }
+
+  if(output == ""){
+    std::cerr << "--output argument required" << std::endl;
+    return 1;
+  }
+  if(listFilesTXT == "" && input == ""){
+    std::cerr << "--input argument required" << std::endl;
+    return 1;
+  }
+
+  /*
+  bool overwrite = false;
+  for (int i = 1; i < argc; ++i) {
+    if(std::string(argv[i]) == "--overwrite") {
+      overwrite = true;
+      break;
+    }
+  }
+  */
+
+
+
+  //Always saveFullNanoAOD info because we are skimming
+  bool saveFullNanoAOD = true;
+  /*for (int i = 1; i < argc; ++i) {
+    if(std::string(argv[i]) == "--saveFullNanoAOD") {
+      saveFullNanoAOD = true;
+      break;
+    }
+    }*/
+ 
+
+
+  if(isKstFinalState){
+    std::cout << " implementation missing " << std::endl;
+    return -10;
+  }
+
+  TFile* f_new = TFile::Open(output.c_str());
+  if(f_new!=0 && !overwrite){
+    cout<<output<<" already exists, please delete it before converting again"<<endl;
+    return 0;
+  }
+  f_new = TFile::Open(output.c_str(),"RECREATE");
+
+
+  TChain* oldtree = new TChain("Events");
+  if(inputTXT){
+    string reader;
+    std::ifstream inFileLong;
+    inFileLong.open(listFilesTXT.c_str(), std::ios::in);
+
+    while(!inFileLong.eof()){
+      inFileLong >> reader;
+      std::cout << " Adding " << reader << std::endl;
+      oldtree->Add(reader.c_str());
+    }
+  }
+  else   oldtree->Add(input.c_str());
+  NanoAODTree* tree = new NanoAODTree(oldtree);
+
+  TTree* tree_new=new TTree("BToKstllTree","BToKstllTree");
+  if(saveFullNanoAOD)
+    tree_new=tree->GetTree()->CloneTree(0);
+
+
+  //New branches
+  int _BToKstll_sel_index = -1;
+  int _Muon_sel_index = -1; //Probe muon with selection algo.
+  int _Muon_probe_index = -1; //Probe muon for Acc.xEff. = _Muon_sel_index in data
+
+  tree_new->Branch("BToKstll_sel_index",&_BToKstll_sel_index,"BToKstll_sel_index/I");
+  tree_new->Branch("Muon_sel_index",&_Muon_sel_index,"Muon_sel_index/I");
+  tree_new->Branch("Muon_probe_index",&_Muon_probe_index,"Muon_probe_index/I");
+
+
+  int _GenPart_BToKstll_index = -1;
+  int _GenPart_JPsiFromB_index = -1;
+  int _GenPart_KFromB_index = -1;
+  int _GenPart_lep1FromB_index = -1;
+  int _GenPart_lep2FromB_index = -1;
+  int _BToKstll_gen_index = -1;  //index of reco closest to gen (each daughter within 0.1)
+  float _BToKstll_gendR_lep1FromB;
+  float _BToKstll_gendR_lep2FromB;
+  float _BToKstll_gendR_KFromB;
+  float _BToKstll_gen_llMass = -1;
+  float _BToKstll_gen_mass = -1;
+  float _BToKstll_gen_muonTag_hpT = -1;
+
+  //the 3 following are the index of the reco closest to the gen (dR < 0.1)
+  //only for no LT
+  int _Lep1_gen_index = -1;
+  int _Lep2_gen_index = -1;
+  int _KPFCand_gen_index = -1;  
+
+  if(isMC != 0){
+    tree_new->Branch("GenPart_BToKstll_index",&_GenPart_BToKstll_index,"GenPart_BToKstll_index/I");
+    tree_new->Branch("GenPart_JPsiFromB_index",&_GenPart_JPsiFromB_index,"GenPart_JPsiFromB_index/I");
+    tree_new->Branch("GenPart_KFromB_index",&_GenPart_KFromB_index,"GenPart_KFromB_index/I");
+    tree_new->Branch("GenPart_lep1FromB_index",&_GenPart_lep1FromB_index,"GenPart_lep1FromB_index/I");
+    tree_new->Branch("GenPart_lep2FromB_index",&_GenPart_lep2FromB_index,"GenPart_lep2FromB_index/I");
+    tree_new->Branch("BToKstll_gen_index",&_BToKstll_gen_index,"BToKstll_gen_index/I");
+    tree_new->Branch("BToKstll_gendR_lep1FromB",&_BToKstll_gendR_lep1FromB,"BToKstll_gendR_lep1FromB/F");
+    tree_new->Branch("BToKstll_gendR_lep2FromB",&_BToKstll_gendR_lep2FromB,"BToKstll_gendR_lep2FromB/F");
+    tree_new->Branch("BToKstll_gendR_KFromB",&_BToKstll_gendR_KFromB,"BToKstll_gendR_KFromB/F");
+    tree_new->Branch("BToKstll_gen_llMass",&_BToKstll_gen_llMass,"BToKstll_gen_llMass/F");
+    tree_new->Branch("BToKstll_gen_mass",&_BToKstll_gen_mass,"BToKstll_gen_mass/F");
+    tree_new->Branch("BToKstll_gen_muonTag_hpT",&_BToKstll_gen_muonTag_hpT,"BToKstll_gen_muonTag_hpT/F");
+    tree_new->Branch("Lep1_gen_index",&_Lep1_gen_index,"Lep1_gen_index/I");
+    tree_new->Branch("Lep2_gen_index",&_Lep2_gen_index,"Lep2_gen_index/I");
+    tree_new->Branch("KPFCand_gen_index",&_KPFCand_gen_index,"KPFCand_gen_index/I");
+  }
+
+
+  bool _HLT_Mu8p5_IP3p5 = false;
+  bool _HLT_Mu10p5_IP3p5 = false;
+  bool _HLT_Mu9_IP6 = false;
+  bool _HLT_Mu8_IP3 = false;
+  bool _HLT_BPHParking = false;
+
+  bool _Muon_isHLT_BPHParking[kMuonMax];
+
+  tree_new->Branch("HLT_Mu8p5_IP3p5",&_HLT_Mu8p5_IP3p5,"HLT_Mu8p5_IP3p5/O");
+  tree_new->Branch("HLT_Mu10p5_IP3p5",&_HLT_Mu10p5_IP3p5,"HLT_Mu10p5_IP3p5/O");
+  tree_new->Branch("HLT_Mu9_IP6",&_HLT_Mu9_IP6,"HLT_Mu9_IP6/O");
+  tree_new->Branch("HLT_Mu8_IP3",&_HLT_Mu8_IP3,"HLT_Mu8_IP3/O");
+  tree_new->Branch("HLT_BPHParking",&_HLT_BPHParking,"HLT_BPHParking/O");
+  
+  tree_new->Branch("Muon_isHLT_BPHParking",_Muon_isHLT_BPHParking,"Muon_isHLT_BPHParking[nMuon]/O");
+  
+
+  int nentries = tree->GetEntries();
+  std::cout << " Nentries = " << nentries << std::endl;
+  std::cout << " isMC = " << isMC << std::endl;
+  
+  for (int iEntry = 0; iEntry < nentries; ++iEntry){
+    
+    int out = tree->GetEntry(iEntry);
+    if(out<0){
+      std::cout << " Error retrievieng entry #" << iEntry << std::endl;
+      return -1;
+    }
+
+    if(iEntry%10000==0) std::cout << " Entry #" << iEntry << " " << int(100*float(iEntry)/nentries) << "%" << std::endl;
+
+    _BToKstll_sel_index = -1;
+    _Muon_sel_index = -1;  //tag muon
+    _Muon_probe_index = -1;
+
+    _GenPart_BToKstll_index = -1;
+    _GenPart_JPsiFromB_index = -1;
+    _GenPart_KFromB_index = -1;
+    _GenPart_lep1FromB_index = -1;
+    _GenPart_lep2FromB_index = -1;
+    _BToKstll_gen_index = -1; 
+    _BToKstll_gendR_lep1FromB = -1; 
+    _BToKstll_gendR_lep2FromB = -1; 
+    _BToKstll_gendR_KFromB = -1; 
+    _BToKstll_gen_llMass = -1;
+    _BToKstll_gen_mass = -1;
+    _BToKstll_gen_muonTag_hpT = -1;
+    _Lep1_gen_index = -1;
+    _Lep2_gen_index = -1;
+    _KPFCand_gen_index = -1;
+
+    _HLT_Mu8p5_IP3p5 = false;
+    _HLT_Mu10p5_IP3p5 = false;
+    _HLT_Mu9_IP6 = false;
+    _HLT_Mu8_IP3 = false;
+    _HLT_BPHParking = false;
+    
+    //look for trigger muon
+    int nMuon = tree->nMuon;
+    
+    for(int i_mu=0; i_mu<nMuon; i_mu++){
+
+      //Trigger selection + matching
+      _HLT_Mu8p5_IP3p5 = tree->HLT_Mu8p5_IP3p5_part0
+	  || tree->HLT_Mu8p5_IP3p5_part1
+	  || tree->HLT_Mu8p5_IP3p5_part2
+	  || tree->HLT_Mu8p5_IP3p5_part3
+	  || tree->HLT_Mu8p5_IP3p5_part4
+	  || tree->HLT_Mu8p5_IP3p5_part5;
+	_HLT_Mu10p5_IP3p5 = tree->HLT_Mu10p5_IP3p5_part0
+	  || tree->HLT_Mu10p5_IP3p5_part1
+	  || tree->HLT_Mu10p5_IP3p5_part2
+	  || tree->HLT_Mu10p5_IP3p5_part3
+	  || tree->HLT_Mu10p5_IP3p5_part4
+	  || tree->HLT_Mu10p5_IP3p5_part5;
+	_HLT_Mu9_IP6 = tree->HLT_Mu9_IP6_part0
+	  || tree->HLT_Mu9_IP6_part1
+	  || tree->HLT_Mu9_IP6_part2
+	  || tree->HLT_Mu9_IP6_part3
+	  || tree->HLT_Mu9_IP6_part4
+	  || tree->HLT_Mu9_IP6_part5;
+	_HLT_Mu8_IP3 = tree->HLT_Mu8_IP3_part0
+	  || tree->HLT_Mu8_IP3_part1
+	  || tree->HLT_Mu8_IP3_part2
+	  || tree->HLT_Mu8_IP3_part3
+	  || tree->HLT_Mu8_IP3_part4
+	  || tree->HLT_Mu8_IP3_part5;
+	_HLT_BPHParking = _HLT_Mu8p5_IP3p5 || _HLT_Mu10p5_IP3p5 || _HLT_Mu9_IP6 || _HLT_Mu8_IP3;
+
+	TLorentzVector mu;
+	mu.SetPtEtaPhiM(tree->Muon_pt[i_mu],tree->Muon_eta[i_mu],tree->Muon_phi[i_mu],tree->Muon_mass[i_mu]);
+
+	bool isTrigMatched = false;
+	int nTrigObj = tree->nTrigObj;
+	for(int i_trig = 0; i_trig<nTrigObj; i_trig++){
+	  if( tree->TrigObj_id[i_trig]==13 && ((tree->TrigObj_filterBits[i_trig])>>3)&1 ){
+	    TLorentzVector trig;
+	    trig.SetPtEtaPhiM(tree->TrigObj_pt[i_trig],tree->TrigObj_eta[i_trig],tree->TrigObj_phi[i_trig],0);
+	    float dR = mu.DeltaR(trig);
+	    if(dR<0.01){
+	      isTrigMatched = true;
+	      break;
+	    }
+	  }
+	}
+
+	_Muon_isHLT_BPHParking[i_mu] = isTrigMatched;
+    }
+
+
+    //Select the BToKll candidate with reco criteria
+
+    int nBinTree = tree->nBToKstll;
+    float best_B_CL_vtx = -1.;
+    std::vector<std::pair<int, float>> B_vtxCL_idx_val;
+
+    for(int i_Btree=0; i_Btree<nBinTree; ++i_Btree){            
+
+      //Disabled for now
+      //if(tree->BToKstll_kaon_charge[i_BToKmumu]*tree->Muon_charge[_Muon_sel_index]>0) continue; //Only consider BToKmumu with opposite charge to muon
+      
+      //already applied in nanoAOD production
+      if(tree->BToKstll_lep1_charge[i_Btree] * tree->BToKstll_lep2_charge[i_Btree] > 0.) continue;
+
+      float B_CL_vtx = tree->BToKstll_B_CL_vtx[i_Btree];
+      B_vtxCL_idx_val.push_back(std::pair<int, float>(i_Btree, B_CL_vtx));
+      
+      if( best_B_CL_vtx < 0. || B_CL_vtx>best_B_CL_vtx ){
+	best_B_CL_vtx = B_CL_vtx;
+	_BToKstll_sel_index = i_Btree;
+      }
+    }
+
+    //FIXME
+    //here sort the B_vtxCL_idx_val vector by CL_vtx and save in extra branch with sorted order
+    //FIXME
+
+    //Take as tag muon leading soft ID muon + trigger-matched
+
+    if(isMC == 0 && _BToKstll_sel_index<0) continue;
+
+
+    if(_BToKstll_sel_index>=0){
+      
+      for(int i_mu=0; i_mu<nMuon; i_mu++){
+
+	//muon passing soft ID + trigger matched
+	if(!tree->Muon_softId[i_mu] || tree->Muon_pt[i_mu] < genMuPtCut) continue;
+	if(isMC != 2 && !_Muon_isHLT_BPHParking[i_mu]) continue;
+
+	//if lepton lepton just check index 
+	if(isLeptonTrack == 0 && isEleFinalState == 0 && 
+	   (i_mu == tree->BToKstll_lep1_index[_BToKstll_sel_index] || i_mu == tree->BToKstll_lep2_index[_BToKstll_sel_index])) continue;
+
+	//if tracks or electrons of anyway
+	//check dR for leading and subleading
+
+	TLorentzVector lep1_tlv;
+	TLorentzVector lep2_tlv;
+	TLorentzVector muHLT_tlv;
+
+	lep1_tlv.SetPtEtaPhiM(tree->BToKstll_lep1_pt[_BToKstll_sel_index],
+			      tree->BToKstll_lep1_eta[_BToKstll_sel_index],
+			      tree->BToKstll_lep1_phi[_BToKstll_sel_index],
+			      (isEleFinalState == 1) ? ElectronMass_ : MuonMass_);
+	lep2_tlv.SetPtEtaPhiM(tree->BToKstll_lep2_pt[_BToKstll_sel_index],
+			      tree->BToKstll_lep2_eta[_BToKstll_sel_index],
+			      tree->BToKstll_lep2_phi[_BToKstll_sel_index],
+			      (isEleFinalState == 1) ? ElectronMass_ : MuonMass_);
+	muHLT_tlv.SetPtEtaPhiM(tree->Muon_pt[i_mu],
+			       tree->Muon_eta[i_mu],
+			       tree->Muon_phi[i_mu],
+			       MuonMass_);
+
+	float dR_lep1FromHLT = lep1_tlv.DeltaR(muHLT_tlv);
+	if(dR_lep1FromHLT < 0.01) continue;
+	float dR_lep2FromHLT = lep2_tlv.DeltaR(muHLT_tlv);
+	if(dR_lep2FromHLT < 0.01) continue;
+
+	//enough to find 1 extra muon matched to the trigger
+	_Muon_sel_index = i_mu;
+	break;
+      }
+    }
+
+    //!!! Can have selected B->Kstll even without additional tag muons
+    //Needs to ask both BToKstll_sel_index>=0 && Muon_sel_index>=0 for analysis on probe side
+    //BToKstll_sel_index not reset to -1 for potential analysis of the probe side
+    
+
+    //Select the BToKstll candidate based on gen matching
+
+    if(isMC != 0){
+      int nGenPart = tree->nGenPart;
+
+      int leptonID = (isEleFinalState == 1) ? 11 : 13;
+
+      if(isResonant){
+	for(int i_Bu=0; i_Bu<nGenPart; i_Bu++){
+
+	  _GenPart_JPsiFromB_index = -1;
+	  _GenPart_lep1FromB_index = -1;
+	  _GenPart_lep2FromB_index = -1;
+	  _GenPart_KFromB_index = -1;
+
+	  if(abs(tree->GenPart_pdgId[i_Bu])==521){
+	    for(int i_gen=0; i_gen<nGenPart; i_gen++){
+
+	      int pdgId = tree->GenPart_pdgId[i_gen];
+	      int mother_index = tree->GenPart_genPartIdxMother[i_gen];
+
+	      int lep1_index = -1;
+	      int lep2_index = -1;
+
+	      if(abs(pdgId)==443 && mother_index == i_Bu){
+
+		for(int j_gen=0; j_gen<nGenPart; j_gen++){
+		  int pdgId = tree->GenPart_pdgId[j_gen];
+		  int mother_index = tree->GenPart_genPartIdxMother[j_gen];
+		  if(abs(pdgId)==leptonID && mother_index == i_gen && lep1_index < 0)
+		    lep1_index = j_gen;
+		  else if(abs(pdgId)==leptonID && mother_index == i_gen)
+		    lep2_index = j_gen;
+		  if(lep1_index >= 0 && lep2_index >= 0) break;
+		}
+
+		if(lep1_index >= 0 && lep2_index >= 0){
+		  _GenPart_JPsiFromB_index = i_gen;
+		  _GenPart_lep1FromB_index = lep1_index;
+		  _GenPart_lep2FromB_index = lep2_index;
+		}
+		else break;
+
+	      }
+
+	      else if(abs(pdgId)==321 && mother_index == i_Bu) _GenPart_KFromB_index = i_gen;
+
+	      else if(mother_index == i_Bu) break; //Additional B decay products
+	    }
+	  }
+
+	  if(_GenPart_JPsiFromB_index >= 0 && _GenPart_KFromB_index >=0){
+	    _GenPart_BToKstll_index = i_Bu;
+	    break;
+	  }
+	}	
+      }//resonant
+      else{ 
+
+	for(int i_Bu=0; i_Bu<nGenPart; i_Bu++){
+	  _GenPart_JPsiFromB_index = -1;
+	  _GenPart_lep1FromB_index = -1;
+	  _GenPart_lep2FromB_index = -1;
+	  _GenPart_KFromB_index = -1;
+
+	  if(abs(tree->GenPart_pdgId[i_Bu]) == 521){
+
+	    for(int i_gen=0; i_gen<nGenPart; i_gen++){
+
+	      int pdgId = tree->GenPart_pdgId[i_gen];
+	      int mother_index = tree->GenPart_genPartIdxMother[i_gen];
+	      if(abs(pdgId) == leptonID && mother_index == i_Bu && _GenPart_lep1FromB_index < 0)
+		_GenPart_lep1FromB_index = i_gen;
+	      else if(abs(pdgId)==leptonID && mother_index == i_Bu)
+		_GenPart_lep2FromB_index = i_gen;
+	      else if(abs(pdgId)==321 && mother_index == i_Bu)
+		_GenPart_KFromB_index = i_gen;
+	      else if(mother_index == i_Bu) break;
+	    }
+	  }//if B
+
+	  if(_GenPart_lep1FromB_index >= 0 && _GenPart_lep2FromB_index >= 0 && _GenPart_KFromB_index >= 0){
+	    _GenPart_BToKstll_index = i_Bu;
+	    break;
+	  }
+	} //loop over B
+      }// non resonant
+    
+      
+      if(_GenPart_BToKstll_index >= 0){
+
+	//lep1FromB stored a leading daughter
+	if(tree->GenPart_pt[_GenPart_lep2FromB_index] > tree->GenPart_pt[_GenPart_lep1FromB_index]){
+	  int i_temp = _GenPart_lep1FromB_index;
+	  _GenPart_lep1FromB_index = _GenPart_lep2FromB_index;
+	  _GenPart_lep2FromB_index = i_temp;
+	}
+
+	TLorentzVector gen_KFromB_tlv;
+	TLorentzVector gen_lep1FromB_tlv;
+	TLorentzVector gen_lep2FromB_tlv;
+	
+	gen_KFromB_tlv.SetPtEtaPhiM(tree->GenPart_pt[_GenPart_KFromB_index],
+				    tree->GenPart_eta[_GenPart_KFromB_index],
+				    tree->GenPart_phi[_GenPart_KFromB_index],
+				    KaonMass_);
+	gen_lep1FromB_tlv.SetPtEtaPhiM(tree->GenPart_pt[_GenPart_lep1FromB_index],
+				      tree->GenPart_eta[_GenPart_lep1FromB_index],
+				      tree->GenPart_phi[_GenPart_lep1FromB_index],
+				       (isEleFinalState == 1) ? ElectronMass_ : MuonMass_);
+	gen_lep2FromB_tlv.SetPtEtaPhiM(tree->GenPart_pt[_GenPart_lep2FromB_index],
+				       tree->GenPart_eta[_GenPart_lep2FromB_index],
+				       tree->GenPart_phi[_GenPart_lep2FromB_index],
+				       (isEleFinalState == 1) ? ElectronMass_ : MuonMass_);
+
+	_BToKstll_gen_llMass = (gen_lep1FromB_tlv+gen_lep2FromB_tlv).Mag();
+	_BToKstll_gen_mass = (gen_lep1FromB_tlv+gen_lep2FromB_tlv+gen_KFromB_tlv).Mag();
+
+	float best_dR = -1.;
+	
+	for(int i_Btree=0; i_Btree<nBinTree; ++i_Btree){
+
+	  TLorentzVector kaon_tlv;
+	  TLorentzVector lep1_tlv;
+	  TLorentzVector lep2_tlv;
+
+	  kaon_tlv.SetPtEtaPhiM(tree->BToKstll_kaon_pt[i_Btree],
+				tree->BToKstll_kaon_eta[i_Btree],
+				tree->BToKstll_kaon_phi[i_Btree],
+				KaonMass_);
+	  lep1_tlv.SetPtEtaPhiM(tree->BToKstll_lep1_pt[i_Btree],
+				tree->BToKstll_lep1_eta[i_Btree],
+				tree->BToKstll_lep1_phi[i_Btree],
+				(isEleFinalState == 1) ? ElectronMass_ : MuonMass_);
+	  lep2_tlv.SetPtEtaPhiM(tree->BToKstll_lep2_pt[i_Btree],
+				tree->BToKstll_lep2_eta[i_Btree],
+				tree->BToKstll_lep2_phi[i_Btree],
+				(isEleFinalState == 1) ? ElectronMass_ : MuonMass_);
+	  
+	  float dR_KFromB = kaon_tlv.DeltaR(gen_KFromB_tlv);
+	  float dR_lep1FromB = min(lep1_tlv.DeltaR(gen_lep1FromB_tlv), lep2_tlv.DeltaR(gen_lep1FromB_tlv));
+	  float dR_lep2FromB = min(lep1_tlv.DeltaR(gen_lep2FromB_tlv), lep2_tlv.DeltaR(gen_lep2FromB_tlv));
+	  //Should check that same objects not selected twice
+
+	  float dR_tot = dR_KFromB + dR_lep1FromB + dR_lep2FromB; //In case several BToKmumu matches, take the closest one in dR_tot
+
+	  //if( dR_lep1FromB <0.1 && dR_lep2FromB <0.1
+	  //  && 
+	  if(best_dR <0. || dR_tot < best_dR){
+	    best_dR = dR_tot;
+	    _BToKstll_gen_index = i_Btree;
+	    _BToKstll_gendR_lep1FromB = dR_lep1FromB;
+	    _BToKstll_gendR_lep2FromB = dR_lep2FromB;
+	    _BToKstll_gendR_KFromB = dR_KFromB;
+	  }
+	}
+
+	/*
+	float best_dR_lep1FromB = -1.;
+	float best_dR_lep2FromB = -1.;
+	float best_dR_KFromB = -1.;
+	*/
+
+	//for the moment just check best reco closest to gen
+	//for lepton-lepton combination only
+	/*
+	if(!isLeptonTrack){  
+	for(int i_mu=0; i_mu<nMuon; i_mu++){
+
+	  TLorentzVector mu_tlv;
+	  mu_tlv.SetPtEtaPhiM(tree->Muon_pt[i_mu],
+			      tree->Muon_eta[i_mu],
+			      tree->Muon_phi[i_mu],
+			      MuonMass_);
+
+	  float dR_mu1FromB = mu_tlv.DeltaR(gen_mu1FromB_tlv);
+	  float dR_mu2FromB = mu_tlv.DeltaR(gen_mu2FromB_tlv);
+
+	  if(dR_mu1FromB<0.1 && (best_dR_mu1FromB<0. || dR_mu1FromB<best_dR_mu1FromB)){
+	    _Muon_mu1FromB_index = i_mu;
+	    best_dR_mu1FromB = dR_mu1FromB;
+	  }
+	  if(dR_mu2FromB<0.1 && (best_dR_mu2FromB<0. || dR_mu2FromB<best_dR_mu2FromB)){
+	    _Muon_mu2FromB_index = i_mu;
+	    best_dR_mu2FromB = dR_mu2FromB;
+	  }
+	}
+	}//end of lepton-lepton comb
+
+	int nPFCand = tree->nPFCand;
+	for(int i_pf=0;i_pf<nPFCand;i_pf++){
+
+	  if(abs(tree->PFCand_pdgId[i_pf])!=211) continue;
+
+	  TLorentzVector PFCand_tlv;
+	  PFCand_tlv.SetPtEtaPhiM(tree->PFCand_pt[i_pf],tree->PFCand_eta[i_pf],tree->PFCand_phi[i_pf],tree->PFCand_mass[i_pf]);
+
+	  float dR_KFromB = PFCand_tlv.DeltaR(gen_KFromB_tlv);
+
+	  if(dR_KFromB<0.1 && (best_dR_KFromB<0. || dR_KFromB<best_dR_KFromB)){
+	    _PFCand_genKFromB_index = i_pf;
+	    best_dR_KFromB = dR_KFromB;
+	  }
+	}
+	*/
+
+	//Gen muon pt filter on tag
+	bool isTagMuonHighPt = false;
+	for(int i_gen=0; i_gen<nGenPart; i_gen++){
+
+	  int pdgId = tree->GenPart_pdgId[i_gen];
+	  if(abs(pdgId)!=13) continue;
+
+	  //exclude the gen muons that are from the chosen B
+	  if(!isEleFinalState && 
+	     (i_gen == _GenPart_lep1FromB_index || i_gen == _GenPart_lep2FromB_index)) continue;
+	  	  
+	  TLorentzVector gen_tagMu_tlv;
+	  gen_tagMu_tlv.SetPtEtaPhiM(tree->GenPart_pt[i_gen],
+				     tree->GenPart_eta[i_gen],
+				     tree->GenPart_phi[i_gen],
+				     MuonMass_);
+
+	  //In case there are several copies of same muon (with FSR for instance)
+	  if(gen_tagMu_tlv.DeltaR(gen_lep1FromB_tlv) > 0.01 && gen_tagMu_tlv.DeltaR(gen_lep2FromB_tlv) > 0.01 &&
+	     //	     gen_tagMu_tlv.Pt() > 5.){	     
+	     (gen_tagMu_tlv.Pt() > _BToKstll_gen_muonTag_hpT || _BToKstll_gen_muonTag_hpT == -1)){
+	    _BToKstll_gen_muonTag_hpT = gen_tagMu_tlv.Pt();
+	    isTagMuonHighPt = true;
+	    //break;
+	  }
+	}
+	if(!isTagMuonHighPt) continue; //Skip events where the gen filter in MC has been applied to the probe muon
+      }
+
+
+      
+      //Require tag muon non matched to gen muons that are from B
+      /*    
+      if(!isEleFianlState && !isLeptonTrack){
+	bool isTagMuonSoftID = false;
+	for(int i_mu=0; i_mu<nMuon; ++i_mu){
+	  if(i_mu == _Lep_mu1FromB_index || i_mu==_Muon_mu2FromB_index) continue;
+	  if(tree->Muon_softId[i_mu] && tree->Muon_pt[i_mu] > 8.){
+	    isProbeMuonSoftID = true;
+	    _Muon_selgen_index = i_mu;
+	    break;
+	  }
+	  
+	}
+	if(!isProbeMuonSoftID) continue; //Skip events where there is no probe muon passing the soft ID
+      }
+      */
+    }
+
+
+
+    if(isMC == 0){
+      _Muon_probe_index = _Muon_sel_index;
+    }
+    
+    tree_new->Fill();
+  }
+
+
+  f_new->cd();
+  if(!saveFullNanoAOD) tree_new->AddFriend("Events",input.c_str());
+
+  tree_new->Write();
+  f_new->Close();
+  return 0;
+
+}
+
+
+

--- a/NtupleProducer/bin/BToKstllNtupleProducer.cc
+++ b/NtupleProducer/bin/BToKstllNtupleProducer.cc
@@ -26,6 +26,11 @@ float MuonMass_ = 0.10565837;
 float ElectronMass_ = 0.5109989e-3;
 
 
+bool comparePairs(const std::pair<int, float>& i, const std::pair<int, float>& j){
+  return i.second > j.second;
+}
+
+
 int main(int argc, char **argv){
 
   if(argc < 2) {
@@ -192,10 +197,12 @@ int main(int argc, char **argv){
 
   //New branches
   int _BToKstll_sel_index = -1;
+  std::vector<int> _BToKstll_order_index;
   int _Muon_sel_index = -1; //Probe muon with selection algo.
   int _Muon_probe_index = -1; //Probe muon for Acc.xEff. = _Muon_sel_index in data
 
   tree_new->Branch("BToKstll_sel_index",&_BToKstll_sel_index,"BToKstll_sel_index/I");
+  tree_new->Branch("BToKstll_order_index", &_BToKstll_order_index);
   tree_new->Branch("Muon_sel_index",&_Muon_sel_index,"Muon_sel_index/I");
   tree_new->Branch("Muon_probe_index",&_Muon_probe_index,"Muon_probe_index/I");
 
@@ -270,6 +277,7 @@ int main(int argc, char **argv){
     if(iEntry%10000==0) std::cout << " Entry #" << iEntry << " " << int(100*float(iEntry)/nentries) << "%" << std::endl;
 
     _BToKstll_sel_index = -1;
+    _BToKstll_order_index.clear();
     _Muon_sel_index = -1;  //tag muon
     _Muon_probe_index = -1;
 
@@ -371,9 +379,14 @@ int main(int argc, char **argv){
       }
     }
 
-    //FIXME
-    //here sort the B_vtxCL_idx_val vector by CL_vtx and save in extra branch with sorted order
-    //FIXME
+    std::sort(B_vtxCL_idx_val.begin(), B_vtxCL_idx_val.end(), comparePairs);
+    int ipCount = 0;
+    _BToKstll_order_index.resize(B_vtxCL_idx_val.size());
+    for(auto ip : B_vtxCL_idx_val){
+      _BToKstll_order_index[ip.first] = ipCount;
+      ++ipCount;
+    }
+
 
     //Take as tag muon leading soft ID muon + trigger-matched
 

--- a/NtupleProducer/bin/BToKstllNtupleProducer.cc
+++ b/NtupleProducer/bin/BToKstllNtupleProducer.cc
@@ -187,6 +187,7 @@ int main(int argc, char **argv){
 
     while(!inFileLong.eof()){
       inFileLong >> reader;
+      if( inFileLong.eof() ) break;
       std::cout << " Adding " << reader << std::endl;
       oldtree->Add(reader.c_str());
     }

--- a/NtupleProducer/bin/BToKstllNtupleProducer.cc
+++ b/NtupleProducer/bin/BToKstllNtupleProducer.cc
@@ -1,6 +1,7 @@
 // BToKstllNtupleProducer --isMC (0,1,2) --isResonant (0, 1, -1) --isEleFS (0, 1) --isKstFS (0, 1) --isLT (0, 1) --output ("outfile") --input ("inputFile")
 
-// new features => gen_index refers to the closest in dR, no minimum dR required
+// new features => gen_index refers to the closest in dR - provided gen B and decays are within acceptance -, 
+//                 no minimum dR required
 //                 saved branch with dR of gen-reco lep1, lep2, kaon
 //              => for gen_tag_muon do not require minimum pT
 //                 saved branch with highest pT of extra muon (tag candidate)
@@ -25,6 +26,9 @@ float KaonMass_ = 0.493677;
 float MuonMass_ = 0.10565837;
 float ElectronMass_ = 0.5109989e-3;
 
+
+float maxEtacceptance_ = 2.45; //2.4
+float minPtacceptance_ = 0.7;  //1.
 
 bool comparePairs(const std::pair<int, float>& i, const std::pair<int, float>& j){
   return i.second > j.second;
@@ -469,6 +473,10 @@ int main(int argc, char **argv){
 
 		for(int j_gen=0; j_gen<nGenPart; j_gen++){
 		  int pdgId = tree->GenPart_pdgId[j_gen];
+		  float partPt = tree->GenPart_pt[i_gen];
+		  float partEta = tree->GenPart_eta[i_gen];
+		  if(partPt < minPtacceptance_) continue;
+		  if(std::abs(partEta) > maxEtacceptance_) continue;
 		  int mother_index = tree->GenPart_genPartIdxMother[j_gen];
 		  if(abs(pdgId)==leptonID && mother_index == i_gen && lep1_index < 0)
 		    lep1_index = j_gen;
@@ -511,6 +519,10 @@ int main(int argc, char **argv){
 	    for(int i_gen=0; i_gen<nGenPart; i_gen++){
 
 	      int pdgId = tree->GenPart_pdgId[i_gen];
+	      float partPt = tree->GenPart_pt[i_gen];
+	      float partEta = tree->GenPart_eta[i_gen];
+	      if(partPt < minPtacceptance_) continue;
+	      if(std::abs(partEta) > maxEtacceptance_) continue;
 	      int mother_index = tree->GenPart_genPartIdxMother[i_gen];
 	      if(abs(pdgId) == leptonID && mother_index == i_Bu && _GenPart_lep1FromB_index < 0)
 		_GenPart_lep1FromB_index = i_gen;
@@ -529,7 +541,6 @@ int main(int argc, char **argv){
 	} //loop over B
       }// non resonant
     
-      
       if(_GenPart_BToKstll_index >= 0){
 
 	//lep1FromB stored a leading daughter

--- a/NtupleProducer/bin/BuildFile.xml
+++ b/NtupleProducer/bin/BuildFile.xml
@@ -2,6 +2,10 @@
     <use name="tensorflow-cc" />
 </bin>
 
+<bin name="BToKstllNtupleProducer" file="BToKstllNtupleProducer.cc">
+    <use name="root" />
+</bin>
+
 <bin name="BToKmumuNtupleProducer" file="BToKmumuNtupleProducer.cc">
     <use name="root" />
 </bin>

--- a/NtupleProducer/bin/NanoAODTree.h
+++ b/NtupleProducer/bin/NanoAODTree.h
@@ -19,6 +19,9 @@
 #include <TChain.h>
 #include <TTree.h>
 
+const int kLeptonMax = 100; // set to 2 times nTriplets
+const int kBToKstllMax = 50;
+
 const int kMuonMax = 100;
 const int kElectronMax = 100;
 const int kBToKpipiMax = 1000000;
@@ -50,6 +53,26 @@ public :
    float Muon_pfRelIso04_all[kMuonMax];
    bool Muon_softId[kMuonMax];
    bool Muon_mediumId[kMuonMax];
+
+
+   uint nBToKstll;
+   float BToKstll_B_CL_vtx[kBToKstllMax];
+   int BToKstll_lep1_charge[kBToKstllMax];
+   int BToKstll_lep1_index[kBToKstllMax];
+   float BToKstll_lep1_pt[kBToKstllMax];
+   float BToKstll_lep1_eta[kBToKstllMax];
+   float BToKstll_lep1_phi[kBToKstllMax];
+   int BToKstll_lep2_charge[kBToKstllMax];
+   int BToKstll_lep2_index[kBToKstllMax];
+   float BToKstll_lep2_pt[kBToKstllMax];
+   float BToKstll_lep2_eta[kBToKstllMax];
+   float BToKstll_lep2_phi[kBToKstllMax];
+   //int BToKstll_kaon_charge[kBToKstllMax];
+   float BToKstll_kaon_pt[kBToKstllMax];
+   float BToKstll_kaon_eta[kBToKstllMax];
+   float BToKstll_kaon_phi[kBToKstllMax];
+
+
 
    uint nElectron;
    int Electron_charge[kElectronMax];
@@ -226,6 +249,27 @@ void NanoAODTree::Init(TChain* tree)
   _tree->SetBranchAddress("Electron_mass",&Electron_mass);
   _tree->SetBranchAddress("Electron_dxy",&Electron_dxy);
   _tree->SetBranchAddress("Electron_dz",&Electron_dz);
+
+
+  int BToKstll_info = _tree->SetBranchAddress("nBToKstll",&nBToKstll);
+  if(BToKstll_info >= 0){
+    _tree->SetBranchAddress("BToKstll_B_CL_vtx",&BToKstll_B_CL_vtx);
+    _tree->SetBranchAddress("BToKstll_lep1_charge",&BToKstll_lep1_charge);
+    _tree->SetBranchAddress("BToKstll_lep1_index",&BToKstll_lep1_index);
+    _tree->SetBranchAddress("BToKstll_lep1_pt",&BToKstll_lep1_pt);
+    _tree->SetBranchAddress("BToKstll_lep1_eta",&BToKstll_lep1_eta);
+    _tree->SetBranchAddress("BToKstll_lep1_phi",&BToKstll_lep1_phi);
+    _tree->SetBranchAddress("BToKstll_lep2_charge",&BToKstll_lep2_charge);
+    _tree->SetBranchAddress("BToKstll_lep2_index",&BToKstll_lep2_index);
+    _tree->SetBranchAddress("BToKstll_lep2_pt",&BToKstll_lep2_pt);
+    _tree->SetBranchAddress("BToKstll_lep2_eta",&BToKstll_lep2_eta);
+    _tree->SetBranchAddress("BToKstll_lep2_phi",&BToKstll_lep2_phi);
+    //_tree->SetBranchAddress("BToKstll_kaon_charge",&BToKstll_kaon_charge);
+    _tree->SetBranchAddress("BToKstll_kaon_pt",&BToKstll_kaon_pt);
+    _tree->SetBranchAddress("BToKstll_kaon_eta",&BToKstll_kaon_eta);
+    _tree->SetBranchAddress("BToKstll_kaon_phi",&BToKstll_kaon_phi);
+  }
+
 
   int BToKpipi_info = _tree->SetBranchAddress("nBToKpipi",&nBToKpipi);
   if(BToKpipi_info>=0){

--- a/NtupleProducer/macro/analyzeCharged_fastDATA_Kstll.cpp
+++ b/NtupleProducer/macro/analyzeCharged_fastDATA_Kstll.cpp
@@ -527,14 +527,12 @@ int main(int argc, char **argv){
   TH1F* hLep1pt_EE[7];
   TH1F* hLep2pt_EE[7];
   TH1F* hBpt[7];
-  TH1F* hllMass[7];
-  TH1F* hllRefitMass[7];
-  TH1F* hllPrefitMass[7];
-  TH2F* hllMass_vs_Bmass[7];
+  TH1F* hllRefitMass[7];  
+  TH2F* hllRefitMass_vs_Bmass[7];
   TH1F* hBmass[7];
 
   for(int ij=0; ij<7; ++ij){
-    hAlpha[ij] = new TH1F(Form("hAlpha_bin%d", ij), "", 500, 0, 1.1);
+    hAlpha[ij] = new TH1F(Form("hAlpha_%d", ij), "", 500, 0, 1.1);
     hAlpha[ij]->Sumw2();
     hAlpha[ij]->SetLineColor(kRed);
     hAlpha[ij]->SetLineWidth(2);
@@ -559,20 +557,10 @@ int main(int argc, char **argv){
     hllRefitMass[ij]->SetLineColor(kRed);
     hllRefitMass[ij]->SetLineWidth(2);
 
-    hllPrefitMass[ij] = new TH1F(Form("hllPrefitMass_%d", ij), "", 750, 0., 15.);
-    hllPrefitMass[ij]->Sumw2();
-    hllPrefitMass[ij]->SetLineColor(kRed);
-    hllPrefitMass[ij]->SetLineWidth(2);
-
-    hllMass[ij] = new TH1F(Form("hllMass_%d", ij), "", 750, 0., 15.);
-    hllMass[ij]->Sumw2();
-    hllMass[ij]->SetLineColor(kRed);
-    hllMass[ij]->SetLineWidth(2);
-
-    hllMass_vs_Bmass[ij] = new TH2F(Form("hllMass_vs_Bmass_%d", ij), "", 500, 0., 15., 500, 0., 15.);
-    hllMass_vs_Bmass[ij]->Sumw2();
-    hllMass_vs_Bmass[ij]->SetMarkerColor(kRed);
-    hllMass_vs_Bmass[ij]->SetMarkerStyle(20);
+    hllRefitMass_vs_Bmass[ij] = new TH2F(Form("hllRefitMass_vs_Bmass_%d", ij), "", 500, 0., 15., 500, 0., 15.);
+    hllRefitMass_vs_Bmass[ij]->Sumw2();
+    hllRefitMass_vs_Bmass[ij]->SetMarkerColor(kRed);
+    hllRefitMass_vs_Bmass[ij]->SetMarkerStyle(20);
 
     hBmass[ij] = new TH1F(Form("Bmass_%d", ij), "", 750, 0., 15.); // 75, 4.5, 6.);
     hBmass[ij]->Sumw2();
@@ -752,13 +740,13 @@ int main(int argc, char **argv){
       else hLep2pt_EE[massBin]->Fill(BToKstll_lep2_pt[BToKstll_sel_index]);
 
       hllRefitMass[massBin]->Fill(llInvRefitMass);
-      hllMass_vs_Bmass[massBin]->Fill(BToKstll_B_mass[BToKstll_sel_index], llInvRefitMass);
+      hllRefitMass_vs_Bmass[massBin]->Fill(BToKstll_B_mass[BToKstll_sel_index], llInvRefitMass);
       hBmass[massBin]->Fill(BToKstll_B_mass[BToKstll_sel_index]);
     }
     
     //histograms inclusive over all m(ll)
     hllRefitMass[6]->Fill(llInvRefitMass);
-    hllMass_vs_Bmass[6]->Fill(BToKstll_B_mass[BToKstll_sel_index], llInvRefitMass);
+    hllRefitMass_vs_Bmass[6]->Fill(BToKstll_B_mass[BToKstll_sel_index], llInvRefitMass);
     hBmass[6]->Fill(BToKstll_B_mass[BToKstll_sel_index]);
     
     hAlpha[6]->Fill(BToKstll_B_cosAlpha[BToKstll_sel_index]);
@@ -809,10 +797,8 @@ int main(int argc, char **argv){
     hBpt[ij]->Write(hBpt[ij]->GetName());
     std::cout << " >>> hBpt[ij]->GetName() = " << hBpt[ij]->GetName() << " entries = " << hBpt[ij]->GetEntries() << std::endl;
 
-    hllMass[ij]->Write(hllMass[ij]->GetName());
     hllRefitMass[ij]->Write(hllRefitMass[ij]->GetName());
-    hllPrefitMass[ij]->Write(hllPrefitMass[ij]->GetName());
-    hllMass_vs_Bmass[ij]->Write(hllMass_vs_Bmass[ij]->GetName());
+    hllRefitMass_vs_Bmass[ij]->Write(hllRefitMass_vs_Bmass[ij]->GetName());
     hBmass[ij]->Write(hBmass[ij]->GetName());
 
     if(ij > 5) continue;

--- a/NtupleProducer/macro/analyzeCharged_fastDATA_Kstll.cpp
+++ b/NtupleProducer/macro/analyzeCharged_fastDATA_Kstll.cpp
@@ -1,0 +1,826 @@
+//g++ -Wall -o analyzeCharged_fastDATA_Kstll `root-config --cflags --glibs` -lRooFitCore analyzeCharged_fastDATA_Kstll.cpp
+
+//./analyzeCharged_fastDATA_Kstll --isEle (0,1) --dataset (-1, runA, runB, runD, MC) --run (1,2,3,...) --typeSelection (tightCB) --ntupleList (list.txt) --JOBid (1,2..) --outputFolder ("outfolder") --nMaxEvents (-1, N) --saveSelectedNTU (1,0) --outSelectedNTU (path for selected ntuples)
+
+
+#include <iostream>
+#include <fstream>
+#include <cstdio>
+#include <cstdlib>
+
+#include "TApplication.h"
+#include "TAxis.h"
+#include "TCanvas.h"
+#include "TChain.h"
+#include "TCut.h"
+#include "TError.h"
+#include "TF1.h"
+#include "TFile.h"
+#include "TGraphErrors.h"
+#include "TH1F.h"
+#include "TH2F.h"
+#include "TKey.h"
+#include "TLegend.h"
+#include "TMath.h"
+#include "TPad.h"
+#include "TROOT.h"
+#include "TString.h"
+#include "TStyle.h"
+#include "TSystem.h"
+#include "TTree.h"
+
+#include "RooAddPdf.h"
+#include "RooCBShape.h"
+#include "RooChebychev.h"
+#include "RooDataHist.h"
+#include "RooDataSet.h"
+#include "RooFitResult.h"
+#include "RooGaussian.h"
+#include "RooMsgService.h"
+#include "RooPlot.h"
+#include "RooRealVar.h"
+#include "RooWorkspace.h"
+
+#include <TLorentzVector.h>
+
+using namespace RooFit;
+
+const int kBToKstllMax = 50000;
+const int kMuonMax = 100;
+const int kPFCandMax = 10000;
+const int kGenPartMax = 10000;
+const float ElectronMass = 0.5109989e-3;
+const float MuonMass = 0.10565837;
+const float KaonMass = 0.493677;
+const float PionMass = 0.139570;
+
+int main(int argc, char **argv){
+
+  if(argc < 2) {
+    std::cout << " Missing arguments " << std::endl;
+    return -1;
+  }
+  int isEleFinalState = -1;
+  std::string dataset = "-1";
+  std::string BPHRun = "-1";
+  std::string typeSelection = "-1";
+  std::string ntupleList = "-1";
+  std::string JOBid = "-1";
+  std::string outputFolder = "-1";
+  int nMaxEvents = -1;
+  int saveOUTntu = 0;
+  std::string outSelectedNTU = "-1";
+  for (int i = 1; i < argc; ++i) {
+    if(std::string(argv[i]) == "--isEle") {
+      if (i + 1 < argc) {
+	isEleFinalState = atoi(argv[i+1]);
+	break;
+      } else {
+	std::cerr << " --isEle option requires one argument " << std::endl;
+	return 1;
+      }
+    }
+  }  for (int i = 1; i < argc; ++i) {
+    if(std::string(argv[i]) == "--dataset") {
+      if (i + 1 < argc) {
+        dataset = argv[i+1];
+        break;
+      } else {
+	std::cerr << " --dataset option requires one argument " << std::endl;
+        return 1;
+      }
+    }
+  }  for (int i = 1; i < argc; ++i) {
+    if(std::string(argv[i]) == "--run") {
+      if (i + 1 < argc) {
+        BPHRun = argv[i+1];
+        break;
+      } else {
+	std::cerr << " --run option requires one argument " << std::endl;
+        return 1;
+      }
+    }
+  }  for (int i = 1; i < argc; ++i) {
+    if(std::string(argv[i]) == "--typeSelection") {
+      if (i + 1 < argc) {
+        typeSelection = argv[i+1];
+        break;
+      } else {
+	std::cerr << " --typeSelection option requires one argument " << std::endl;
+        return 1;
+      }
+    }
+  }  for (int i = 1; i < argc; ++i) {
+    if(std::string(argv[i]) == "--ntupleList") {
+      if (i + 1 < argc) {
+        ntupleList = argv[i+1];
+        break;
+      } else {
+	std::cerr << " --ntupleList option requires one argument " << std::endl;
+        return 1;
+      }
+    }
+  }  for (int i = 1; i < argc; ++i) {
+    if(std::string(argv[i]) == "--JOBid") {
+      if (i + 1 < argc) {
+        JOBid = argv[i+1];
+        break;
+      } else {
+	std::cerr << " --JOBid option requires one argument " << std::endl;
+        return 1;
+      }
+    }
+  }  for (int i = 1; i < argc; ++i) {
+    if(std::string(argv[i]) == "--outputFolder") {
+      if (i + 1 < argc) {
+        outputFolder = argv[i+1];
+        break;
+      } else {
+	std::cerr << " --outputFolder option requires one argument " << std::endl;
+        return 1;
+      }
+    }
+  }  for (int i = 1; i < argc; ++i) {
+    if(std::string(argv[i]) == "--nMaxEvents") {
+      if (i + 1 < argc) {
+        nMaxEvents = atoi(argv[i+1]);
+        break;
+      } else {
+	std::cerr << " --nMaxEvents option requires one argument " << std::endl;
+        return 1;
+      }
+    }
+  }  for (int i = 1; i < argc; ++i) {
+    if(std::string(argv[i]) == "--saveSelectedNTU") {
+      if (i + 1 < argc) {
+        saveOUTntu = atoi(argv[i+1]);
+        break;
+      } else {
+	std::cerr << " --saveSelectedNTU option requires one argument " << std::endl;
+        return 1;
+      }
+    }
+  }  for (int i = 1; i < argc; ++i) {
+    if(std::string(argv[i]) == "--outSelectedNTU") {
+      if (i + 1 < argc) {
+        outSelectedNTU = argv[i+1];
+        break;
+      } else {
+	std::cerr << " --outSelectedNTU option requires one argument " << std::endl;
+        return 1;
+      }
+    }
+  }
+
+
+  if(ntupleList != "-1" && (JOBid == "-1" || outputFolder == "-1")){
+    std::cout << " configuration ERROR => splitting file based but missing JOBid and output folder " << std::endl;
+    return -1;
+  }
+
+  if(saveOUTntu != 0 && outSelectedNTU == "-1"){
+    std::cout << " configuration ERROR => missing output folder for final trees " << std::endl;
+    return -1;
+  }
+
+  std::cout << " isEleFinalState = " << isEleFinalState << " dataset = " << dataset << " BPHRun = " << BPHRun << " typeSelection = " << typeSelection
+	    << " ntupleList = " << ntupleList << " JOBid = " << JOBid << " outputFolder = " << outputFolder
+	    << " nMaxEvents = " << nMaxEvents << " saveOUTntu = " << saveOUTntu << " outSelectedNTU = " << outSelectedNTU << std::endl;
+
+
+  gROOT->Reset();
+  gROOT->Macro("./setStyle.C");
+  gSystem->Load("libRooFit") ;
+  gStyle->SetOptStat(0);
+  gStyle->SetOptFit(0);
+
+  TChain* t1 = new TChain("Events");
+  
+  if(ntupleList != "-1"){
+    std::string rootFileName;
+    std::ifstream inFileLong;
+    inFileLong.open(ntupleList.c_str(), std::ios::in);
+    while(!inFileLong.eof()){
+        if(inFileLong >> rootFileName){
+            t1->Add(rootFileName.c_str());
+            std::cout << " adding " << rootFileName << std::endl;
+        }
+    }
+  }
+
+  //      To be updated                       
+  /* 
+  else{
+    if(isEleFinalState){
+    
+        if((dataset == "runA" && BPHRun == "1") || dataset == "-1") t1->Add("");
+        if((dataset == "runA" && BPHRun == "2") || dataset == "-1") t1->Add("");
+        if((dataset == "runA" && BPHRun == "3") || dataset == "-1") t1->Add("");
+        if((dataset == "runA" && BPHRun == "4") || dataset == "-1") t1->Add("");
+        if((dataset == "runA" && BPHRun == "5") || dataset == "-1") t1->Add("");
+        if((dataset == "runA" && BPHRun == "6") || dataset == "-1") t1->Add("");
+
+        if((dataset == "runB" && BPHRun == "1") || dataset == "-1") t1->Add("");
+        if((dataset == "runB" && BPHRun == "2") || dataset == "-1") t1->Add("");
+        if((dataset == "runB" && BPHRun == "3") || dataset == "-1") t1->Add("");
+        if((dataset == "runB" && BPHRun == "4") || dataset == "-1") t1->Add("");
+        if((dataset == "runB" && BPHRun == "5") || dataset == "-1") t1->Add(""); 
+        
+        if((dataset == "runD" && BPHRun == "1") || dataset == "-1") t1->Add("");
+        if((dataset == "runD" && BPHRun == "2") || dataset == "-1") t1->Add("");
+        if((dataset == "runD" && BPHRun == "3") || dataset == "-1") t1->Add("");
+        if((dataset == "runD" && BPHRun == "4") || dataset == "-1") t1->Add("");
+        if((dataset == "runD" && BPHRun == "5") || dataset == "-1") t1->Add("");
+    
+        if(dataset == "MC" && BPHRun == "nnResonant"){
+            t1->Add("");
+        }
+    
+        if(dataset == "MC" && BPHRun == "Resonant"){
+            t1->Add("");
+        }
+    
+    }
+    else{
+    
+        if((dataset == "runA" && BPHRun == "1") || dataset == "-1") t1->Add("");
+        if((dataset == "runA" && BPHRun == "2") || dataset == "-1") t1->Add("");
+        if((dataset == "runA" && BPHRun == "3") || dataset == "-1") t1->Add("");
+        if((dataset == "runA" && BPHRun == "4") || dataset == "-1") t1->Add("");
+        if((dataset == "runA" && BPHRun == "5") || dataset == "-1") t1->Add("");
+        if((dataset == "runA" && BPHRun == "6") || dataset == "-1") t1->Add("");
+
+        if((dataset == "runB" && BPHRun == "1") || dataset == "-1") t1->Add("");
+        if((dataset == "runB" && BPHRun == "2") || dataset == "-1") t1->Add("");
+        if((dataset == "runB" && BPHRun == "3") || dataset == "-1") t1->Add("");
+        if((dataset == "runB" && BPHRun == "4") || dataset == "-1") t1->Add("");
+        if((dataset == "runB" && BPHRun == "5") || dataset == "-1") t1->Add("");       
+    
+        if((dataset == "runD" && BPHRun == "1") || dataset == "-1") t1->Add("");
+        if((dataset == "runD" && BPHRun == "2") || dataset == "-1") t1->Add("");
+        if((dataset == "runD" && BPHRun == "3") || dataset == "-1") t1->Add("");
+        if((dataset == "runD" && BPHRun == "4") || dataset == "-1") t1->Add("");
+        if((dataset == "runD" && BPHRun == "5") || dataset == "-1") t1->Add("");
+        
+        if(dataset == "MC" && BPHRun == "nnResonant"){
+            t1->Add("");
+        }
+    
+        if(dataset == "MC" && BPHRun == "Resonant"){
+            t1->Add("");
+        }
+        
+    }
+    
+  }
+  */
+  
+  int nEvts = t1->GetEntries();
+  std::cout << " #initial n. events: " << nEvts << std::endl;
+
+  std::string outNtuName = "selectedEvents_Kee_"+dataset+"_BPHRun"+BPHRun;
+  if(!isEleFinalState) outNtuName = "selectedEvents_Kmumu_"+dataset+"_BPHRun"+BPHRun;
+  if(JOBid != "-1") outNtuName = outSelectedNTU+"/"+outNtuName+"_JOB_"+JOBid;
+  outNtuName += ".root";
+  gROOT->cd();
+  TFile* newFile;
+  TTree* newT;
+
+  Float_t Kstll_pt;
+  Float_t Kstll_mass;
+  Float_t Kstll_cosAlpha;
+  Float_t Kstll_CL_vtx;
+  Float_t Kstll_Lxy;
+  Float_t Kstll_ctxy;
+
+  Float_t Kstll_l1_pt;
+  Float_t Kstll_l1_eta;
+  Float_t Kstll_l1_phi;
+  Float_t Kstll_l1_preFpt;
+  Float_t Kstll_l1_preFeta;
+  Float_t Kstll_l1_preFphi;
+  Float_t Kstll_l1_pfRelIso03;
+  Float_t Kstll_l1_pfRelIso04;
+  Float_t Kstll_l1_dxy;
+  Float_t Kstll_l1_dz;
+  
+  Float_t Kstll_l2_pt;
+  Float_t Kstll_l2_eta;
+  Float_t Kstll_l2_phi;
+  Float_t Kstll_l2_preFpt;
+  Float_t Kstll_l2_preFeta;
+  Float_t Kstll_l2_preFphi;
+  Float_t Kstll_l2_pfRelIso03;
+  Float_t Kstll_l2_pfRelIso04;
+  Float_t Kstll_l2_dxy;
+  Float_t Kstll_l2_dz;
+  
+  Float_t Kstll_llRefitmass;
+
+  Int_t   Kstll_k_charge;
+  Float_t Kstll_k_pt;
+  Float_t Kstll_k_eta;
+  Float_t Kstll_k_phi;
+  Float_t Kstll_k_DCASig;
+  Float_t Kstll_k_dxy;
+  Float_t Kstll_k_dz;
+
+  if(saveOUTntu){
+    newFile = new TFile(outNtuName.c_str(),"recreate");
+    newT = new TTree("selectedEvents", "");
+
+    newT->Branch("Kstll_pt", &Kstll_pt, "Kstll_pt/F");         
+    newT->Branch("Kstll_mass", &Kstll_mass, "Kstll_mass/F");    
+    newT->Branch("Kstll_cosAlpha", &Kstll_cosAlpha, "Kstll_cosAlpha/F");
+    newT->Branch("Kstll_CL_vtx", &Kstll_CL_vtx, "Kstll_CL_vtx/F");
+    newT->Branch("Kstll_Lxy", &Kstll_Lxy, "Kstll_Lxy/F");
+    newT->Branch("Kstll_ctxy", &Kstll_ctxy, "Kstll_ctxy/F");
+
+    newT->Branch("Kstll_l1_pt", &Kstll_l1_pt, "Kstll_l1_pt/F");
+    newT->Branch("Kstll_l1_eta", &Kstll_l1_eta, "Kstll_l1_eta/F");
+    newT->Branch("Kstll_l1_phi", &Kstll_l1_phi, "Kstll_l1_phi/F");
+    newT->Branch("Kstll_l1_preFpt", &Kstll_l1_preFpt, "Kstll_l1_preFpt/F");
+    newT->Branch("Kstll_l1_preFeta", &Kstll_l1_preFeta, "Kstll_l1_preFeta/F");
+    newT->Branch("Kstll_l1_preFphi", &Kstll_l1_preFphi, "Kstll_l1_preFphi/F");
+    newT->Branch("Kstll_l1_pfRelIso03", &Kstll_l1_pfRelIso03, "Kstll_l1_pfRelIso03/F");
+    newT->Branch("Kstll_l1_pfRelIso04", &Kstll_l1_pfRelIso04, "Kstll_l1_pfRelIso04/F");
+    newT->Branch("Kstll_l1_dxy", &Kstll_l1_dxy, "Kstll_l1_dxy/F");
+    newT->Branch("Kstll_l1_dz", &Kstll_l1_dz, "Kstll_l1_dz/F");
+    
+    newT->Branch("Kstll_l2_pt", &Kstll_l2_pt, "Kstll_l2_pt/F");
+    newT->Branch("Kstll_l2_eta", &Kstll_l2_eta, "Kstll_l2_eta/F");
+    newT->Branch("Kstll_l2_phi", &Kstll_l2_phi, "Kstll_l2_phi/F");
+    newT->Branch("Kstll_l2_preFpt", &Kstll_l2_preFpt, "Kstll_l2_preFpt/F");
+    newT->Branch("Kstll_l2_preFeta", &Kstll_l2_preFeta, "Kstll_l2_preFeta/F");
+    newT->Branch("Kstll_l2_preFphi", &Kstll_l2_preFphi, "Kstll_l2_preFphi/F");
+    newT->Branch("Kstll_l2_pfRelIso03", &Kstll_l2_pfRelIso03, "Kstll_l2_pfRelIso03/F");
+    newT->Branch("Kstll_l2_pfRelIso04", &Kstll_l2_pfRelIso04, "Kstll_l2_pfRelIso04/F");
+    newT->Branch("Kstll_l2_dxy", &Kstll_l2_dxy, "Kstll_l2_dxy/F");
+    newT->Branch("Kstll_l2_dz", &Kstll_l2_dz, "Kstll_l2_dz/F");
+    
+    newT->Branch("Kstll_llRefitmass", &Kstll_llRefitmass, "Kstll_llRefitmass/F");
+
+    newT->Branch("Kstll_k_charge", &Kstll_k_charge, "Kstll_k_charge/I");    
+    newT->Branch("Kstll_k_pt", &Kstll_k_pt, "Kstll_k_pt/F");
+    newT->Branch("Kstll_k_eta", &Kstll_k_eta, "Kstll_k_eta/F");
+    newT->Branch("Kstll_k_phi", &Kstll_k_phi, "Kstll_k_phi/F");
+    newT->Branch("Kstll_k_DCASig", &Kstll_k_DCASig, "Kstll_k_DCASig/F");    
+    newT->Branch("Kstll_k_dxy", &Kstll_k_dxy, "Kstll_k_dxy/F");
+    newT->Branch("Kstll_k_dz", &Kstll_k_dz, "Kstll_k_dz/F");
+  }
+
+  std::cout << " >>> so far so good " << std::endl;
+
+  UInt_t run = 0;
+  UInt_t lumi = 0;
+  ULong64_t event = 0;
+  
+  //float nnBMX = -1;
+
+  int BToKstll_sel_index = -1;
+  int MuonTag_index = -1;
+  int MuonRecoTag_index = -1;
+  
+  float BToKstll_B_pt[kBToKstllMax];
+  float BToKstll_B_mass[kBToKstllMax];
+  float BToKstll_B_cosAlpha[kBToKstllMax];
+  float BToKstll_B_CL_vtx[kBToKstllMax];
+  float BToKstll_B_Lxy[kBToKstllMax];
+  float BToKstll_B_ctxy[kBToKstllMax];
+  
+  int   BToKstll_lep1_charge[kBToKstllMax];
+  int   BToKstll_lep1_index[kBToKstllMax];
+  float BToKstll_lep1_pt[kBToKstllMax];
+  float BToKstll_lep1_eta[kBToKstllMax];
+  float BToKstll_lep1_phi[kBToKstllMax];
+  
+  int   BToKstll_lep2_charge[kBToKstllMax];
+  int   BToKstll_lep2_index[kBToKstllMax];  
+  float BToKstll_lep2_pt[kBToKstllMax];
+  float BToKstll_lep2_eta[kBToKstllMax];
+  float BToKstll_lep2_phi[kBToKstllMax];
+  
+  float BToKstll_ll_mass[kBToKstllMax];
+  
+  int   BToKstll_kaon_charge[kBToKstllMax];
+  int   BToKstll_kaon_index[kBToKstllMax];
+  float BToKstll_kaon_pt[kBToKstllMax];
+  float BToKstll_kaon_eta[kBToKstllMax];
+  float BToKstll_kaon_phi[kBToKstllMax];
+  float BToKstll_kaon_DCASig[kBToKstllMax];
+
+  float PFCand_dxy[kPFCandMax];
+  float PFCand_dz[kPFCandMax];
+  
+  int   BToKstll_gen_index = -1;
+  
+  float Lepton_pfRelIso03[kMuonMax];
+  float Lepton_pfRelIso04[kMuonMax];
+  float Lepton_pt[kMuonMax];
+  float Lepton_eta[kMuonMax];
+  float Lepton_phi[kMuonMax];
+  float Lepton_dxy[kMuonMax];
+  float Lepton_dz[kMuonMax];
+  
+  
+  t1->SetBranchStatus("*", 0);
+
+
+  t1->SetBranchStatus("run", 1);                        t1->SetBranchAddress("run", &run);
+  t1->SetBranchStatus("luminosityBlock", 1);            t1->SetBranchAddress("luminosityBlock", &lumi);
+  t1->SetBranchStatus("event", 1);                      t1->SetBranchAddress("event", &event);
+  
+  t1->SetBranchStatus("BToKstll_sel_index", 1);         t1->SetBranchAddress("BToKstll_sel_index", &BToKstll_sel_index);
+
+  t1->SetBranchStatus("BToKstll_B_pt", 1);              t1->SetBranchAddress("BToKstll_B_pt", &BToKstll_B_pt);
+  t1->SetBranchStatus("BToKstll_B_mass", 1);            t1->SetBranchAddress("BToKstll_B_mass", &BToKstll_B_mass);
+  t1->SetBranchStatus("BToKstll_B_cosAlpha", 1);        t1->SetBranchAddress("BToKstll_B_cosAlpha", &BToKstll_B_cosAlpha);
+  t1->SetBranchStatus("BToKstll_B_CL_vtx", 1);          t1->SetBranchAddress("BToKstll_B_CL_vtx", &BToKstll_B_CL_vtx);
+  t1->SetBranchStatus("BToKstll_B_Lxy", 1);             t1->SetBranchAddress("BToKstll_B_Lxy", &BToKstll_B_Lxy);
+  t1->SetBranchStatus("BToKstll_B_ctxy", 1);            t1->SetBranchAddress("BToKstll_B_ctxy", &BToKstll_B_ctxy);
+  
+  t1->SetBranchStatus("BToKstll_lep1_charge", 1);       t1->SetBranchAddress("BToKstll_lep1_charge", &BToKstll_lep1_charge);
+  t1->SetBranchStatus("BToKstll_lep1_index", 1);        t1->SetBranchAddress("BToKstll_lep1_index", &BToKstll_lep1_index);
+  t1->SetBranchStatus("BToKstll_lep1_pt", 1);           t1->SetBranchAddress("BToKstll_lep1_pt", &BToKstll_lep1_pt);
+  t1->SetBranchStatus("BToKstll_lep1_eta", 1);          t1->SetBranchAddress("BToKstll_lep1_eta", &BToKstll_lep1_eta);
+  t1->SetBranchStatus("BToKstll_lep1_phi", 1);          t1->SetBranchAddress("BToKstll_lep1_phi", &BToKstll_lep1_phi);
+  
+  t1->SetBranchStatus("BToKstll_lep2_charge", 1);       t1->SetBranchAddress("BToKstll_lep2_charge", &BToKstll_lep2_charge);
+  t1->SetBranchStatus("BToKstll_lep2_index", 1);        t1->SetBranchAddress("BToKstll_lep2_index", &BToKstll_lep2_index);
+  t1->SetBranchStatus("BToKstll_lep2_pt", 1);           t1->SetBranchAddress("BToKstll_lep2_pt", &BToKstll_lep2_pt);
+  t1->SetBranchStatus("BToKstll_lep2_eta", 1);          t1->SetBranchAddress("BToKstll_lep2_eta", &BToKstll_lep2_eta);
+  t1->SetBranchStatus("BToKstll_lep2_phi", 1);          t1->SetBranchAddress("BToKstll_lep2_phi", &BToKstll_lep2_phi);
+  
+  t1->SetBranchStatus("BToKstll_ll_mass", 1);           t1->SetBranchAddress("BToKstll_ll_mass", &BToKstll_ll_mass);          
+
+  t1->SetBranchStatus("BToKstll_kaon_charge", 1);       t1->SetBranchAddress("BToKstll_kaon_charge", &BToKstll_kaon_charge);  
+  t1->SetBranchStatus("BToKstll_kaon_index", 1);        t1->SetBranchAddress("BToKstll_kaon_index", &BToKstll_kaon_index);  
+  t1->SetBranchStatus("BToKstll_kaon_pt", 1);           t1->SetBranchAddress("BToKstll_kaon_pt", &BToKstll_kaon_pt);
+  t1->SetBranchStatus("BToKstll_kaon_eta", 1);          t1->SetBranchAddress("BToKstll_kaon_eta", &BToKstll_kaon_eta);
+  t1->SetBranchStatus("BToKstll_kaon_phi", 1);          t1->SetBranchAddress("BToKstll_kaon_phi", &BToKstll_kaon_phi);
+  t1->SetBranchStatus("BToKstll_kaon_DCASig", 1);       t1->SetBranchAddress("BToKstll_kaon_DCASig", &BToKstll_kaon_DCASig);
+
+  t1->SetBranchStatus("PFCand_dxy", 1);                 t1->SetBranchAddress("PFCand_dxy", &PFCand_dxy);
+  t1->SetBranchStatus("PFCand_dz", 1);                  t1->SetBranchAddress("PFCand_dz", &PFCand_dz);
+
+  
+  if(dataset == "MC"){      
+    t1->SetBranchStatus("BToKstll_gen_index", 1);       t1->SetBranchAddress("BToKstll_gen_index", &BToKstll_gen_index);
+  }
+  
+  
+  if(isEleFinalState){    
+    t1->SetBranchStatus("Muon_sel_index", 1);           t1->SetBranchAddress("Muon_sel_index", &MuonTag_index);
+      
+    t1->SetBranchStatus("Electron_pfRelIso03_all", 1);  t1->SetBranchAddress("Electron_pfRelIso03_all", &Lepton_pfRelIso03);
+    t1->SetBranchStatus("Electron_pt", 1);              t1->SetBranchAddress("Electron_pt", &Lepton_pt);
+    t1->SetBranchStatus("Electron_eta", 1);             t1->SetBranchAddress("Electron_eta", &Lepton_eta);
+    t1->SetBranchStatus("Electron_phi", 1);             t1->SetBranchAddress("Electron_phi", &Lepton_phi);
+    t1->SetBranchStatus("Electron_dxy", 1);             t1->SetBranchAddress("Electron_dxy", &Lepton_dxy);
+    t1->SetBranchStatus("Electron_dz", 1);              t1->SetBranchAddress("Electron_dz", &Lepton_dz);
+  }
+  else{    
+    t1->SetBranchStatus("Muon_probe_index", 1);         t1->SetBranchAddress("Muon_probe_index", &MuonTag_index);
+    t1->SetBranchStatus("Muon_sel_index", 1);           t1->SetBranchAddress("Muon_sel_index", &MuonRecoTag_index);  
+      
+    t1->SetBranchStatus("Muon_pfRelIso03_all", 1);      t1->SetBranchAddress("Muon_pfRelIso03_all", &Lepton_pfRelIso03);
+    t1->SetBranchStatus("Muon_pfRelIso04_all", 1);      t1->SetBranchAddress("Muon_pfRelIso04_all", &Lepton_pfRelIso04);
+    t1->SetBranchStatus("Muon_pt", 1);                  t1->SetBranchAddress("Muon_pt", &Lepton_pt);
+    t1->SetBranchStatus("Muon_eta", 1);                 t1->SetBranchAddress("Muon_eta", &Lepton_eta);
+    t1->SetBranchStatus("Muon_phi", 1);                 t1->SetBranchAddress("Muon_phi", &Lepton_phi);
+    t1->SetBranchStatus("Muon_dxy", 1);                 t1->SetBranchAddress("Muon_dxy", &Lepton_dxy);
+    t1->SetBranchStatus("Muon_dz", 1);                  t1->SetBranchAddress("Muon_dz", &Lepton_dz);        
+    
+    //if(typeSelection == "NN_BkgR" || typeSelection == "NN_SigEff"){
+    //    t1->SetBranchStatus("nnBMX", 1);                t1->SetBranchAddress("nnBMX", &nnBMX);
+    //}
+  }
+
+  
+  std::vector<float> llMassBoundary;
+  llMassBoundary.push_back(0.);
+  llMassBoundary.push_back(1.);
+  llMassBoundary.push_back(2.5);
+  llMassBoundary.push_back(2.9);
+  llMassBoundary.push_back(3.3);
+  llMassBoundary.push_back(3.58);
+  llMassBoundary.push_back(100.);
+
+
+  std::string outName = "outMassHistos_Kee_"+dataset+"_BPHRun"+BPHRun;
+  if(!isEleFinalState) outName = "outMassHistos_Kmumu_"+dataset+"_BPHRun"+BPHRun;
+  if(JOBid != "-1") outName = outputFolder; // + "/" +outName + "_JOB_"+JOBid;
+  else  outName += ".root";
+  TFile outMassHistos(outName.c_str(), "recreate");
+
+  ///histos: 1 per bin plus inclusive
+  TH1F* hAlpha[7];
+  TH1F* hCLVtx[7];
+  TH1F* hDCASig[7];
+  TH1F* hLxy[7];
+  TH1F* hctxy[7];
+  TH1F* hKaonpt[7];
+  TH1F* hLep1pt[7];
+  TH1F* hLep2pt[7];
+  TH1F* hLep1pt_EB[7];
+  TH1F* hLep2pt_EB[7];
+  TH1F* hLep1pt_EE[7];
+  TH1F* hLep2pt_EE[7];
+  TH1F* hBpt[7];
+  TH1F* hllMass[7];
+  TH1F* hllRefitMass[7];
+  TH1F* hllPrefitMass[7];
+  TH2F* hllMass_vs_Bmass[7];
+  TH1F* hBmass[7];
+
+  for(int ij=0; ij<7; ++ij){
+    hAlpha[ij] = new TH1F(Form("hAlpha_bin%d", ij), "", 500, 0, 1.1);
+    hAlpha[ij]->Sumw2();
+    hAlpha[ij]->SetLineColor(kRed);
+    hAlpha[ij]->SetLineWidth(2);
+
+    hCLVtx[ij] = new TH1F(Form("hCLVtx_%d", ij), "", 100, 0., 1.);
+    hCLVtx[ij]->Sumw2();
+    hCLVtx[ij]->SetLineColor(kRed);
+    hCLVtx[ij]->SetLineWidth(2);
+ 
+    hDCASig[ij] = new TH1F(Form("hDCASig_%d", ij), "", 100, -50., 50.);
+    hDCASig[ij]->Sumw2();
+    hDCASig[ij]->SetLineColor(kRed);
+    hDCASig[ij]->SetLineWidth(2);
+
+    hLxy[ij] = new TH1F(Form("hLxy_%d", ij), "", 100, 0., 100.);
+    hLxy[ij]->Sumw2();
+    hLxy[ij]->SetLineColor(kRed);
+    hLxy[ij]->SetLineWidth(2);
+
+    hllRefitMass[ij] = new TH1F(Form("hllRefitMass_%d", ij), "", 750, 0., 15.);
+    hllRefitMass[ij]->Sumw2();
+    hllRefitMass[ij]->SetLineColor(kRed);
+    hllRefitMass[ij]->SetLineWidth(2);
+
+    hllPrefitMass[ij] = new TH1F(Form("hllPrefitMass_%d", ij), "", 750, 0., 15.);
+    hllPrefitMass[ij]->Sumw2();
+    hllPrefitMass[ij]->SetLineColor(kRed);
+    hllPrefitMass[ij]->SetLineWidth(2);
+
+    hllMass[ij] = new TH1F(Form("hllMass_%d", ij), "", 750, 0., 15.);
+    hllMass[ij]->Sumw2();
+    hllMass[ij]->SetLineColor(kRed);
+    hllMass[ij]->SetLineWidth(2);
+
+    hllMass_vs_Bmass[ij] = new TH2F(Form("hllMass_vs_Bmass_%d", ij), "", 500, 0., 15., 500, 0., 15.);
+    hllMass_vs_Bmass[ij]->Sumw2();
+    hllMass_vs_Bmass[ij]->SetMarkerColor(kRed);
+    hllMass_vs_Bmass[ij]->SetMarkerStyle(20);
+
+    hBmass[ij] = new TH1F(Form("Bmass_%d", ij), "", 750, 0., 15.); // 75, 4.5, 6.);
+    hBmass[ij]->Sumw2();
+    hBmass[ij]->SetLineColor(kRed);
+    hBmass[ij]->SetLineWidth(2);
+
+    hctxy[ij] = new TH1F(Form("hctxy_%d", ij), "", 1000, 0., 10.);
+    hctxy[ij]->Sumw2();
+    hctxy[ij]->SetLineColor(kRed);
+    hctxy[ij]->SetLineWidth(2);
+
+    hKaonpt[ij] = new TH1F(Form("hKaonpt_%d", ij), "", 100, 0., 10.);
+    hKaonpt[ij]->Sumw2();
+    hKaonpt[ij]->SetLineColor(kRed);
+    hKaonpt[ij]->SetLineWidth(2);
+
+    hLep1pt[ij] = new TH1F(Form("hLep1pt_%d", ij), "", 100, 0., 10.);
+    hLep1pt[ij]->Sumw2();
+    hLep1pt[ij]->SetLineColor(kRed);
+    hLep1pt[ij]->SetLineWidth(2);
+
+    hLep2pt[ij] = new TH1F(Form("hLep2pt_%d", ij), "", 100, 0., 10.);
+    hLep2pt[ij]->Sumw2();
+    hLep2pt[ij]->SetLineColor(kRed);
+    hLep2pt[ij]->SetLineWidth(2);
+
+    //
+    hLep1pt_EB[ij] = new TH1F(Form("hLep1pt_EB_%d", ij), "", 100, 0., 10.);
+    hLep1pt_EB[ij]->Sumw2();
+    hLep1pt_EB[ij]->SetLineColor(kRed);
+    hLep1pt_EB[ij]->SetLineWidth(2);
+
+    hLep2pt_EB[ij] = new TH1F(Form("hLep2pt_EB_%d", ij), "", 100, 0., 10.);
+    hLep2pt_EB[ij]->Sumw2();
+    hLep2pt_EB[ij]->SetLineColor(kRed);
+    hLep2pt_EB[ij]->SetLineWidth(2);
+
+    //
+    hLep1pt_EE[ij] = new TH1F(Form("hLep1pt_EE_%d", ij), "", 100, 0., 10.);
+    hLep1pt_EE[ij]->Sumw2();
+    hLep1pt_EE[ij]->SetLineColor(kRed);
+    hLep1pt_EE[ij]->SetLineWidth(2);
+
+    hLep2pt_EE[ij] = new TH1F(Form("hLep2pt_EE_%d", ij), "", 100, 0., 10.);
+    hLep2pt_EE[ij]->Sumw2();
+    hLep2pt_EE[ij]->SetLineColor(kRed);
+    hLep2pt_EE[ij]->SetLineWidth(2);
+
+    hBpt[ij] = new TH1F(Form("hBpt_%d", ij), "", 200, 0., 100.);
+    hBpt[ij]->Sumw2();
+    hBpt[ij]->SetLineColor(kRed);
+    hBpt[ij]->SetLineWidth(2);
+  }
+
+
+  float nEv_muonTag[1] = {0.};
+  float nEv_recoCand[1] = {0.};
+  float nEv_chargeSel[1] = {0.};
+  float nEv_selected[7] = {0.};
+
+
+  if(nMaxEvents == -1) nMaxEvents = nEvts;
+  for(int iEvt = 0; iEvt<nMaxEvents; ++iEvt){
+    if(iEvt%500000 == 0) std::cout << " >>> processing event " << iEvt << " " << 1.*iEvt/nEvts*100. << std::endl;
+
+    t1->GetEntry(iEvt);
+
+    if(MuonTag_index == -1) continue;
+    if(!isEleFinalState && MuonRecoTag_index == -1) continue;
+    ++nEv_muonTag[0];
+
+    if(BToKstll_sel_index == -1) continue; 
+    if(dataset == "MC" && BPHRun == "nnResonant" && BToKstll_sel_index != BToKstll_gen_index) continue;
+    ++nEv_recoCand[0]; 
+
+    //opposite sign leptons
+    if(BToKstll_lep1_charge[BToKstll_sel_index]*BToKstll_lep2_charge[BToKstll_sel_index] > 0.) continue;
+    ++nEv_chargeSel[0];
+
+    //misleading it's refit for Kmumu default for Kee
+    float llInvRefitMass = BToKstll_ll_mass[BToKstll_sel_index];
+    int massBin = -1;
+    for(unsigned int kl=0; kl<llMassBoundary.size()-1; ++kl){
+      if(llInvRefitMass >= llMassBoundary[kl] && llInvRefitMass < llMassBoundary[kl+1]){
+	massBin = kl;
+	break;
+      }
+    }
+
+    //to synch. with Riccardo ~ tight selection
+    if(typeSelection == "tightCB"){
+      if((BToKstll_kaon_pt[BToKstll_sel_index] < 1.5 || BToKstll_B_pt[BToKstll_sel_index] < 10.)) continue;
+      if(BToKstll_B_cosAlpha[BToKstll_sel_index] < 0.999) continue;
+      if(BToKstll_B_CL_vtx[BToKstll_sel_index] < 0.1) continue;
+      if(BToKstll_B_Lxy[BToKstll_sel_index] < 6.) continue;
+    }
+
+    //MVA selection to get same background rejection as with the cut base
+    //if(typeSelection == "NN_BkgR" && nnBMX < 0.993) continue;
+
+    //MVA selection to get same signal efficiency as with the cut base
+    //if(typeSelection == "NN_SigEff" && nnBMX < 0.998) continue;
+
+    if(massBin != -1) ++nEv_selected[massBin];
+    else ++nEv_selected[6];
+
+    
+    //save output ntuple with selected events fro final plots
+    if(saveOUTntu){
+        
+	Kstll_pt = BToKstll_B_pt[BToKstll_sel_index];     
+	Kstll_mass = BToKstll_B_mass[BToKstll_sel_index];
+	Kstll_cosAlpha = BToKstll_B_cosAlpha[BToKstll_sel_index];
+	Kstll_CL_vtx = BToKstll_B_CL_vtx[BToKstll_sel_index];
+	Kstll_Lxy = BToKstll_B_Lxy[BToKstll_sel_index];
+	Kstll_ctxy = BToKstll_B_ctxy[BToKstll_sel_index];
+    
+	Kstll_l1_pt = BToKstll_lep1_pt[BToKstll_sel_index];	
+	Kstll_l1_eta = BToKstll_lep1_eta[BToKstll_sel_index];
+	Kstll_l1_phi = BToKstll_lep1_phi[BToKstll_sel_index];
+	Kstll_l1_preFpt = Lepton_pt[BToKstll_lep1_index[BToKstll_sel_index]];
+	Kstll_l1_preFeta = Lepton_eta[BToKstll_lep1_index[BToKstll_sel_index]];
+	Kstll_l1_preFphi = Lepton_phi[BToKstll_lep1_index[BToKstll_sel_index]];
+	Kstll_l1_pfRelIso03 = Lepton_pfRelIso03[BToKstll_lep1_index[BToKstll_sel_index]];
+	Kstll_l1_dxy = Lepton_dxy[BToKstll_lep1_index[BToKstll_sel_index]];
+	Kstll_l1_dz = Lepton_dz[BToKstll_lep1_index[BToKstll_sel_index]];
+    
+	Kstll_l2_pt = BToKstll_lep2_pt[BToKstll_sel_index];
+	Kstll_l2_eta = BToKstll_lep2_eta[BToKstll_sel_index];
+	Kstll_l2_phi = BToKstll_lep2_phi[BToKstll_sel_index];
+	Kstll_l2_preFpt = Lepton_pt[BToKstll_lep2_index[BToKstll_sel_index]];
+	Kstll_l2_preFeta = Lepton_eta[BToKstll_lep2_index[BToKstll_sel_index]];
+	Kstll_l2_preFphi = Lepton_phi[BToKstll_lep2_index[BToKstll_sel_index]];
+	Kstll_l2_pfRelIso03 = Lepton_pfRelIso03[BToKstll_lep2_index[BToKstll_sel_index]];
+	Kstll_l2_dxy = Lepton_dxy[BToKstll_lep2_index[BToKstll_sel_index]];
+	Kstll_l2_dz = Lepton_dz[BToKstll_lep2_index[BToKstll_sel_index]];
+
+	if(isEleFinalState){
+	  Kstll_l1_pfRelIso04 = -1.;
+	  Kstll_l2_pfRelIso04 = -1.;
+	}
+	else{
+	Kstll_l1_pfRelIso04 = Lepton_pfRelIso04[BToKstll_lep1_index[BToKstll_sel_index]];
+	Kstll_l2_pfRelIso04 = Lepton_pfRelIso04[BToKstll_lep2_index[BToKstll_sel_index]];
+	}
+	
+    Kstll_llRefitmass = llInvRefitMass;
+
+    Kstll_k_charge = BToKstll_kaon_charge[BToKstll_sel_index];
+	Kstll_k_pt = BToKstll_kaon_pt[BToKstll_sel_index];
+	Kstll_k_eta = BToKstll_kaon_eta[BToKstll_sel_index];
+	Kstll_k_phi = BToKstll_kaon_phi[BToKstll_sel_index];
+	Kstll_k_DCASig = BToKstll_kaon_DCASig[BToKstll_sel_index];
+	Kstll_k_dxy = PFCand_dxy[BToKstll_kaon_index[BToKstll_sel_index]];
+	Kstll_k_dz = PFCand_dz[BToKstll_kaon_index[BToKstll_sel_index]];
+
+	newT->Fill();
+    }
+    //end output Nutuple
+
+    
+    //histograms for each mass bin
+    if(massBin != -1){
+      hAlpha[massBin]->Fill(BToKstll_B_cosAlpha[BToKstll_sel_index]);
+      hCLVtx[massBin]->Fill(BToKstll_B_CL_vtx[BToKstll_sel_index]);
+      hDCASig[massBin]->Fill(BToKstll_kaon_DCASig[BToKstll_sel_index]);
+      hLxy[massBin]->Fill(BToKstll_B_Lxy[BToKstll_sel_index]);
+      hctxy[massBin]->Fill(BToKstll_B_ctxy[BToKstll_sel_index]);
+      hKaonpt[massBin]->Fill(BToKstll_kaon_pt[BToKstll_sel_index]);
+      hBpt[massBin]->Fill(BToKstll_B_pt[BToKstll_sel_index]);
+
+      hLep1pt[massBin]->Fill(BToKstll_lep1_pt[BToKstll_sel_index]);
+      hLep2pt[massBin]->Fill(BToKstll_lep2_pt[BToKstll_sel_index]);
+      if(std::abs(BToKstll_lep1_eta[BToKstll_sel_index]) < 1.47) hLep1pt_EB[massBin]->Fill(BToKstll_lep1_pt[BToKstll_sel_index]);
+      else hLep1pt_EE[massBin]->Fill(BToKstll_lep1_pt[BToKstll_sel_index]);
+      if(std::abs(BToKstll_lep2_eta[BToKstll_sel_index]) < 1.47) hLep2pt_EB[massBin]->Fill(BToKstll_lep2_pt[BToKstll_sel_index]);
+      else hLep2pt_EE[massBin]->Fill(BToKstll_lep2_pt[BToKstll_sel_index]);
+
+      hllRefitMass[massBin]->Fill(llInvRefitMass);
+      hllMass_vs_Bmass[massBin]->Fill(BToKstll_B_mass[BToKstll_sel_index], llInvRefitMass);
+      hBmass[massBin]->Fill(BToKstll_B_mass[BToKstll_sel_index]);
+    }
+    
+    //histograms inclusive over all m(ll)
+    hllRefitMass[6]->Fill(llInvRefitMass);
+    hllMass_vs_Bmass[6]->Fill(BToKstll_B_mass[BToKstll_sel_index], llInvRefitMass);
+    hBmass[6]->Fill(BToKstll_B_mass[BToKstll_sel_index]);
+    
+    hAlpha[6]->Fill(BToKstll_B_cosAlpha[BToKstll_sel_index]);
+    hCLVtx[6]->Fill(BToKstll_B_CL_vtx[BToKstll_sel_index]);
+    hDCASig[6]->Fill(BToKstll_kaon_DCASig[BToKstll_sel_index]);
+    hLxy[6]->Fill(BToKstll_B_Lxy[BToKstll_sel_index]);
+    hctxy[6]->Fill(BToKstll_B_ctxy[BToKstll_sel_index]);
+    hKaonpt[6]->Fill(BToKstll_kaon_pt[BToKstll_sel_index]);
+    hBpt[6]->Fill(BToKstll_B_pt[BToKstll_sel_index]);
+
+    hLep1pt[6]->Fill(BToKstll_lep1_pt[BToKstll_sel_index]);
+    hLep2pt[6]->Fill(BToKstll_lep2_pt[BToKstll_sel_index]);
+    if(std::abs(BToKstll_lep1_eta[BToKstll_sel_index]) < 1.47) hLep1pt_EB[6]->Fill(BToKstll_lep1_pt[BToKstll_sel_index]);
+    else hLep1pt_EE[6]->Fill(BToKstll_lep1_pt[BToKstll_sel_index]);
+    if(std::abs(BToKstll_lep2_eta[BToKstll_sel_index]) < 1.47) hLep2pt_EB[6]->Fill(BToKstll_lep2_pt[BToKstll_sel_index]);
+    else hLep2pt_EE[6]->Fill(BToKstll_lep2_pt[BToKstll_sel_index]);
+
+    /*
+    if(massBin == 3 && BToKstll_B_mass[BToKstll_sel_index] < 6.)
+      std::cout << run << " " << lumi << " " << event << std::endl;
+    */
+  }//loop over events
+
+  
+  if(saveOUTntu){
+    newFile->cd();
+    newT->Write();
+    newFile->Close(); 
+  }
+
+  outMassHistos.cd();
+  
+  std::cout << " ***** summary ***** "<< std::endl;
+  for(int ij=0; ij<7; ++ij){
+    hAlpha[ij]->Write(hAlpha[ij]->GetName());
+    hCLVtx[ij]->Write(hCLVtx[ij]->GetName());
+    hDCASig[ij]->Write(hDCASig[ij]->GetName());
+    hLxy[ij]->Write(hLxy[ij]->GetName());
+    hctxy[ij]->Write(hctxy[ij]->GetName());
+    hKaonpt[ij]->Write(hKaonpt[ij]->GetName());
+    hLep1pt[ij]->Write(hLep1pt[ij]->GetName());
+    hLep2pt[ij]->Write(hLep2pt[ij]->GetName());
+    hLep1pt_EB[ij]->Write(hLep1pt_EB[ij]->GetName());
+    hLep1pt_EE[ij]->Write(hLep1pt_EE[ij]->GetName());
+    hLep2pt_EB[ij]->Write(hLep2pt_EB[ij]->GetName());
+    hLep2pt_EE[ij]->Write(hLep2pt_EE[ij]->GetName());
+
+    hBpt[ij]->Write(hBpt[ij]->GetName());
+    std::cout << " >>> hBpt[ij]->GetName() = " << hBpt[ij]->GetName() << " entries = " << hBpt[ij]->GetEntries() << std::endl;
+
+    hllMass[ij]->Write(hllMass[ij]->GetName());
+    hllRefitMass[ij]->Write(hllRefitMass[ij]->GetName());
+    hllPrefitMass[ij]->Write(hllPrefitMass[ij]->GetName());
+    hllMass_vs_Bmass[ij]->Write(hllMass_vs_Bmass[ij]->GetName());
+    hBmass[ij]->Write(hBmass[ij]->GetName());
+
+    if(ij > 5) continue;
+    std::cout << "\n massBin: " << llMassBoundary[ij] << " - " << llMassBoundary[ij+1]
+	      << " \n \t muonTag = " << nEv_muonTag[0] << " \t recoEvts = " << nEv_recoCand[0]
+              << " \n \t chargeSel = " << nEv_chargeSel[0] << " \t selected Events = " << nEv_selected[ij] << std::endl;
+
+  }
+  outMassHistos.Close();
+
+}  

--- a/NtupleProducer/macro/analyzeCharged_fastDATA_Kstll.cpp
+++ b/NtupleProducer/macro/analyzeCharged_fastDATA_Kstll.cpp
@@ -413,6 +413,9 @@ int main(int argc, char **argv){
   float PFCand_dz[kPFCandMax];
   
   int   BToKstll_gen_index = -1;
+  float BToKstll_gendR_lep1FromB[kMuonMax];
+  float BToKstll_gendR_lep2FromB[kMuonMax];
+  float BToKstll_gendR_KFromB[kMuonMax];
   
   float Lepton_pfRelIso03[kMuonMax];
   float Lepton_pfRelIso04[kMuonMax];
@@ -466,6 +469,9 @@ int main(int argc, char **argv){
   
   if(dataset == "MC"){      
     t1->SetBranchStatus("BToKstll_gen_index", 1);       t1->SetBranchAddress("BToKstll_gen_index", &BToKstll_gen_index);
+    t1->SetBranchStatus("BToKstll_gendR_lep1FromB", 1); t1->SetBranchAddress("BToKstll_gendR_lep1FromB", &BToKstll_gendR_lep1FromB);
+    t1->SetBranchStatus("BToKstll_gendR_lep2FromB", 1); t1->SetBranchAddress("BToKstll_gendR_lep2FromB", &BToKstll_gendR_lep2FromB);
+    t1->SetBranchStatus("BToKstll_gendR_KFromB", 1);    t1->SetBranchAddress("BToKstll_gendR_KFromB", &BToKstll_gendR_KFromB);
   }
   
   
@@ -634,6 +640,7 @@ int main(int argc, char **argv){
 
     if(BToKstll_sel_index == -1) continue; 
     if(dataset == "MC" && BPHRun == "nnResonant" && BToKstll_sel_index != BToKstll_gen_index) continue;
+    if( dataset == "MC" && ( BToKstll_gendR_lep1FromB[BToKstll_gen_index]>0.1 || BToKstll_gendR_lep2FromB[BToKstll_gen_index]>0.1 || BToKstll_gendR_KFromB[BToKstll_gen_index]>0.1 ) )continue;
     ++nEv_recoCand[0]; 
 
     //opposite sign leptons

--- a/NtupleProducer/macro/computeAE_charged_fitBmass_Kstll.C
+++ b/NtupleProducer/macro/computeAE_charged_fitBmass_Kstll.C
@@ -1,0 +1,237 @@
+//compute double ratio nnReso/JPsi  event counts following all levels of selections
+//muonTag + 
+//gen Acceptance +
+//gen Efficiency (reco final state matched to gen level) +
+//selections for the analysis in data  
+
+//should be ok for electron final state 
+//example to run
+//electron final state
+//root -l computeAE_charged_fitBmass_Kstll.C'("/path-to-the-Kee-directory/ntu_MC_PR38_BToKee.root", "/path-to-the-KJPsiee-directory/ntu_MC_PR38_BToKJPsiee.root", 1, true)' 
+//muon final state
+//root -l computeAE_charged_fitBmass_Kstll.C'("/path-to-the-Kmumu-directory/ntu_MC_PR38_BToKmumu.root", "/path-to-the-KJPsimumu-directory/ntu_MC_PR38_BToKJPsimumu.root", 0, true)' 
+
+
+#include <iostream>
+#include <fstream>
+#include <cstdio>
+#include <cstdlib>
+
+#include "TROOT.h"
+#include "TSystem.h"
+#include "TKey.h"
+#include "TFile.h"
+#include "TTree.h"
+#include "TH1F.h"
+#include "TH2F.h"
+#include "TF1.h"
+#include "TString.h"
+#include "TCut.h"
+#include "TMath.h"
+#include "TApplication.h"
+#include "TError.h"
+#include "TGraphErrors.h"
+#include "TPad.h"
+#include "TMultiGraph.h"
+#include "TStyle.h"
+#include "TChain.h"
+
+#include "RooRealVar.h"
+#include "RooDataSet.h"
+#include "RooDataHist.h"
+#include "RooGaussian.h"
+#include "RooChebychev.h"
+#include "RooCBShape.h"
+#include "RooAddPdf.h"
+#include "RooWorkspace.h"
+#include "RooFitResult.h"
+#include "TCanvas.h"
+#include "TAxis.h"
+#include "RooPlot.h"
+
+using namespace RooFit;
+
+
+void computeAE_charged_fitBmass_Kstll(std::string nonResonantFile, std::string ResonantFile, int isEleFinalState, bool foldGenMassBin=true){
+
+  gROOT->Reset();
+  gROOT->Macro("setStyle.C");
+
+  gStyle->SetOptStat(0);
+  gStyle->SetOptFit(0);
+
+
+  std::cout << " isEleFinalState = " << isEleFinalState << std::endl;
+
+  TChain* t1 = new TChain("Events");
+  TChain* t2 = new TChain("Events");
+
+  t1->Add(nonResonantFile.c_str());
+  t2->Add(ResonantFile.c_str());
+
+
+  //muon tag with soft ID https://twiki.cern.ch/twiki/bin/viewauth/CMS/SWGuideMuonIdRun2#Soft_Muon
+  int nMuonTag_nonReso = t1->GetEntries();
+  int nMuonTag_Reso = t2->GetEntries();
+
+  std::cout << " #muon tag events: nnreso = " << nMuonTag_nonReso << " resonant = " << nMuonTag_Reso << std::endl;
+
+  //if false => move to reco ee invariant mass bins
+
+   //selections
+  std::string cut_muonTag = "Muon_sel_index != -1";
+  if(!isEleFinalState){
+    cut_muonTag = "Muon_probe_index != -1";
+  }
+  std::string cut_Recocandidate = "BToKstll_sel_index != -1 && BToKstll_gen_index != -1 && BToKstll_sel_index == BToKstll_gen_index";
+  std::string cut_chargeEff = "BToKstll_lep1_charge[BToKstll_sel_index]*BToKstll_lep2_charge[BToKstll_sel_index] < 0.";
+  std::string cut_pTEff = "BToKstll_B_pt[BToKstll_sel_index] >= 10. && BToKstll_kaon_pt[BToKstll_sel_index] >= 1.5";
+  std::string cut_alphaEff = "BToKstll_B_cosAlpha[BToKstll_sel_index] >= 0.999";
+  std::string cut_vtxCLEff = "BToKstll_B_CL_vtx[BToKstll_sel_index] >= 0.1";  
+  std::string cut_LxyEff  = "BToKstll_B_Lxy[BToKstll_sel_index] >= 6"; 
+
+  std::vector<std::string> llMassCut;
+  std::vector<std::string> llGenMassCut;
+
+  std::vector<float> llMassBoundary;
+  llMassBoundary.push_back(0.);
+  llMassBoundary.push_back(1.);
+  llMassBoundary.push_back(2.5);
+  llMassBoundary.push_back(2.9);
+  llMassBoundary.push_back(3.3);
+  llMassBoundary.push_back(3.58);
+  llMassBoundary.push_back(100.);
+
+  
+  for(int ij=0; ij<6; ++ij){
+    
+    std::string cut = Form("BToKstll_ll_mass[BToKstll_sel_index] > %.2f && BToKstll_ll_mass[BToKstll_sel_index] < %.2f",            
+    llMassBoundary.at(ij), llMassBoundary.at(ij+1));
+    
+    std::string gencut = Form("BToKstll_gen_llMass > %.2f && BToKstll_gen_llMass < %.2f", llMassBoundary.at(ij), llMassBoundary.at(ij+1));
+    
+    llMassCut.push_back(cut);
+    if(foldGenMassBin) llGenMassCut.push_back(gencut);
+    else llGenMassCut.push_back(" 1 == 1");  
+      
+  }
+
+  
+  //JPsi first - non resonant last
+  float nEv_muonTag[7] = {0.};
+  float nEv_cuts[7] = {0.};
+  
+
+  TH1F* h_Bmass_llbin[7];
+  h_Bmass_llbin[0] = new TH1F(Form("h_Bmass_JPsi_%.2f-%.2f", llMassBoundary.at(3), llMassBoundary.at(3+1)), "", 1000, 0., 10.);
+    
+  nEv_muonTag[0] = t2->Draw("Muon_sel_index", (cut_muonTag+" && "+llGenMassCut.at(3)).c_str(), "goff");
+  
+  nEv_cuts[0] = t2->Draw(Form("BToKstll_B_mass[BToKstll_sel_index] >> %s", h_Bmass_llbin[0]->GetName()), (cut_muonTag+" && "+cut_Recocandidate+" && "+cut_chargeEff+" && "+cut_pTEff+" && "+cut_alphaEff+" && "+cut_vtxCLEff+" && "+cut_LxyEff+" && "+llMassCut.at(3)+" && "+llGenMassCut.at(3)).c_str());
+  
+  std::cout << " tot JPsi_MC muonTag events = " << nEv_muonTag[0] << std::endl;
+  std::cout << " tot JPsi_MC endSelection Events = " << nEv_cuts[0] << std::endl;
+  
+
+  for(int ij=0; ij<6; ++ij){
+    h_Bmass_llbin[ij+1] = new TH1F(Form("h_Bmass_bin_%.2f-%.2f", llMassBoundary.at(ij), llMassBoundary.at(ij+1)), "", 1000, 0., 10.);
+
+    nEv_muonTag[ij+1] = t1->Draw("Muon_sel_index", (cut_muonTag+" && "+llGenMassCut.at(ij)).c_str(), "goff");
+    
+    nEv_cuts[ij+1] = t1->Draw(Form("BToKstll_B_mass[BToKstll_sel_index] >> %s", h_Bmass_llbin[ij+1]->GetName()), (cut_muonTag+" && "+cut_Recocandidate+" && "+cut_chargeEff+" && "+cut_pTEff+" && "+cut_alphaEff+" && "+cut_vtxCLEff+" && "+cut_LxyEff+" && "+llMassCut.at(ij)+" && "+llGenMassCut.at(ij)).c_str());
+
+    std::cout << " tot nonResonant_MC muonTag events = " << nEv_muonTag[ij+1] << " in mass bin " << llMassCut.at(ij) << std::endl;
+    std::cout << " tot nonResonant_MC endSelection Events = " << nEv_cuts[ij+1] << std::endl;
+  }//loop
+
+
+  std::string outName = "outMassHistos_MC_ee.root";
+  if(!isEleFinalState) outName ="outMassHistos_MC_mumu.root";
+  TFile outMassHistos(outName.c_str(), "recreate");
+  outMassHistos.cd();
+  for(int ij=0; ij<7; ++ij)
+    h_Bmass_llbin[ij]->Write(h_Bmass_llbin[ij]->GetName());
+  outMassHistos.Close();
+
+
+
+  //now fitting
+  float nEv_postFit[7] = {0.};
+  float nEvError_postFit[7] = {0.};
+
+  RooWorkspace w("w");    
+  w.factory("x[0, 10]");  
+  //w.factory("x[4.5, 6.]");  
+
+  w.factory("nbackground[10000, 0, 10000]");   
+  w.factory("nsignal[100, 0.0, 10000.0]");
+
+  for(int ij=0; ij<7; ++ij){
+
+    h_Bmass_llbin[ij]->Rebin(2);
+
+    w.factory("Gaussian::smodel(x,mu[5.3,4.5,6],sigma[0.05,0,0.2])");
+    //w.factory("Gaussian::smodel(x,mu[5.3,4.5,6],sigma[0.05,0,0.2])");
+    //w.factory("RooCBShape::smodel(x,m[5.3,4.5,6],s[0.1,0.,1.],a[1.2,0.,3.],n[1,0.1,6.])");
+    //w.factory("RooCBShape::CBall(x[0,15], mean[11000,13000], sigma[5000,200000], alpha[0,10000],n[0,100000])");
+    RooAbsPdf * smodel = w.pdf("smodel");
+    
+    w.factory("Exponential::bmodel(x,tau[-2,-3,0])");
+    RooAbsPdf * bmodel = w.pdf("bmodel");
+    
+    w.factory("SUM::model(nbackground*bmodel, nsignal*smodel)");
+    RooAbsPdf * model = w.pdf("model");
+    
+    RooDataHist hBMass("hBMass", "hBMass", *w.var("x"), Import(*(h_Bmass_llbin[ij])));
+
+    RooFitResult * r = model->fitTo(hBMass, Minimizer("Minuit2"),Save(true));
+
+    RooPlot * plot = w.var("x")->frame();
+    if(isEleFinalState){
+      if(ij == 0) plot->SetXTitle("K(JPsi)ee mass (GeV)");
+      else plot->SetXTitle("Kee mass (GeV)");
+    }
+    else{
+      if(ij == 0) plot->SetXTitle("K(JPsi)#mu#mu mass (GeV)");
+      else plot->SetXTitle("K#mu#mu mass (GeV)");
+    }
+    plot->SetTitle("");
+    plot->SetAxisRange(4.5,6);
+    hBMass.plotOn(plot);
+    model->plotOn(plot);
+    model->plotOn(plot, Components("bmodel"),LineStyle(kDashed));
+    model->plotOn(plot, Components("smodel"),LineColor(kRed));
+
+    TCanvas * cc = new TCanvas();
+    cc->SetLogy(0);
+    plot->Draw();
+    if(isEleFinalState) cc->Print(Form("plots_computeAE_ee_PR38/computeAE_ee_PR38_%s.png",h_Bmass_llbin[ij]->GetName()), "png");
+    else cc->Print(Form("plots_computeAE_mumu_PR38/computeAE_mumu_PR38_%s.png",h_Bmass_llbin[ij]->GetName()), "png");
+
+    RooRealVar* parS = (RooRealVar*) r->floatParsFinal().find("nsignal");
+    RooRealVar* parB = (RooRealVar*) r->floatParsFinal().find("nbackground");
+    nEv_postFit[ij] = parS->getValV();
+    nEvError_postFit[ij] = parS->getError();
+
+    std::cout << " JPsi selection signal events = \t " << parS->getValV() << " error = " << parS->getError() 
+	      << " bkg events = " << parB->getValV() << " error = " << parB->getError() << std::endl;
+  }
+  
+  float errb = pow(nEvError_postFit[0]/nEv_postFit[0], 2);
+
+  std::cout << " ***** summary ***** "<< std::endl;
+  for(int ij=0; ij<7; ++ij){
+
+    float errRatio = pow(nEvError_postFit[ij]/nEv_postFit[ij], 2) + errb;
+    errRatio = sqrt(errRatio) * nEvError_postFit[ij]/nEvError_postFit[0];
+
+    std::cout << "\n \n  category: " << h_Bmass_llbin[ij]->GetName()
+              << " \t integral muonTag = " << nEv_muonTag[ij]
+              << " evtCount " << nEv_cuts[ij] << " withFit " << nEv_postFit[ij] <<"+/-"<<nEvError_postFit[ij]
+              << "\n \t\t\t eff(/muonTag)    evtCount " << nEv_cuts[ij]/nEv_muonTag[ij]
+              << " withFit " << nEv_postFit[ij]/nEv_muonTag[ij] << "+/-" << nEvError_postFit[ij]/nEv_muonTag[ij]
+              << "\n  \t\t\t double ratio wrt JPsi    evtCount " << (nEv_cuts[ij]/nEv_muonTag[ij])/(nEv_cuts[0]/nEv_muonTag[0])
+              << " withFit " << (nEv_postFit[ij]/nEv_muonTag[ij])/(nEv_postFit[0]/nEv_muonTag[0]) << "+/-"<<errRatio<< std::endl;
+  }
+
+} 

--- a/NtupleProducer/macro/setStyle.C
+++ b/NtupleProducer/macro/setStyle.C
@@ -97,10 +97,7 @@ void setStyle()
   style->SetTitleFont(42, "XYZ");
   style->SetTitleSize(0.06, "XYZ");
   style->SetTitleXOffset(0.9);
-  // style->SetTitleYOffset(1.5);
-  // style->SetTitleYOffset(1.5);
-  style->SetTitleYOffset(1.4);
-  style->SetTitleYOffset(1.4);
+  style->SetTitleYOffset(1.2);
   //  style->SetTitleOffset(1.3,"Y");
                                                                                                                                                                             
   // For the axis labels:  

--- a/NtupleProducer/scripts/config_runAnalyis.sh
+++ b/NtupleProducer/scripts/config_runAnalyis.sh
@@ -1,5 +1,5 @@
 #!/bin/bash 
 cd ../../
-./analyzeCharged_fastDATA --isEle 0 --dataset runA --run 1 --typeSelection tightCB --ntupleList DUMMYINPUTFILELIST --JOBid DUMMYJOBID --outputFolder DUMMYOUTFILENAME
+./analyzeCharged_fastDATA_Kstll --isEle 0 --dataset runA --run 1 --typeSelection tightCB --ntupleList DUMMYINPUTFILELIST --JOBid DUMMYJOBID --outputFolder DUMMYOUTFILENAME
 
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # BPHParkingAnalysis
 Analysis package for analysis of BPH parked data
 
-### Instructions for 10_1_5
+### Instructions for 10_2_5
 ```
-cmsrel CMSSW_10_1_5
+cmsrel CMSSW_10_2_5
 cd CMSSW_10_1_5/src/
 cmsenv
 
 git clone https://github.com/ICBPHCMS/BPHParkingAnalysis.git
-cd BPHParkingAnalysis/NtupleProducer
-git checkout master
+scram b
 ```
 
 ### Producing ntuples
 ```
-sh Make.sh BToKpipiNtupleProducer.cc
-./BToKpipiNtupleProducer.exe mc --input test94X_NANO.root --output test.root
+cd BPHParkingAnalysis/NtupleProducer/bin
+
+BToKstllNtupleProducer --isMC (0,1,2) --isResonant (0, 1, -1) --isEleFS (0, 1) --isKstFS (0, 1) --isLT (0, 1) --output ("outfile") --input ("inputFile")
 ```


### PR DESCRIPTION
* Single ntuple producer to handle Kee Kmumu final state (Star + mumu/ee to be done)
tested on data and MC Kmumu final state

* new features for MC matching
- assume proper trigger path for new MC
- gen_index refers to the closest in dR, no minimum dR required + saved branch with dR of gen-reco lep1, lep2, kaon => as a result every event with reconstructed triplets has BToKstll_gen_index != -1 and can ask offline the dR required
- for gen_tag_muon do not require minimum pT + saved branch with highest pT of extra muon (tag candidate) =>  every event with reconstructed triplets is saved and can ask offline the pT for the gen_tag_muon
- all matching are with dR < 0.01 also for reco tag muon is dR < 0.01
- isMC == 2 is for old - Thomas' - MC; isMC == 1 is new; isMC == 0 is DATA 

* with new features observed slightly higher efficiency for old MC - about 3% more)