### PR TITLE
lowPt Bmass categories

### DIFF
--- a/NtupleProducer/macro/analyzeCharged_fastDATA_Kstll.cpp
+++ b/NtupleProducer/macro/analyzeCharged_fastDATA_Kstll.cpp
@@ -338,7 +338,9 @@ int main(int argc, char **argv){
   std::vector<int>* Muon_tag_index = 0;
   int Muon_sel_index = -1;
   int Muon_probe_index = -1;
-  
+
+  int BToKstll_lep1_isLowPt[kBToKstllMax];
+  int BToKstll_lep2_isLowPt[kBToKstllMax];
   int BToKstll_lep2_isPFLep[kBToKstllMax];
   int BToKstll_isLowPtEle[kBToKstllMax];
   
@@ -406,7 +408,9 @@ int main(int argc, char **argv){
   t1->SetBranchStatus("Muon_tag_index", 1);             t1->SetBranchAddress("Muon_tag_index", &Muon_tag_index);
   t1->SetBranchStatus("Muon_sel_index", 1);             t1->SetBranchAddress("Muon_sel_index", &Muon_sel_index);
   
-  t1->SetBranchStatus("BToKstll_lep2_isPFLep", 1);      t1->SetBranchAddress("BToKstll_lep2_isPFLep", &BToKstll_lep2_isPFLep);  
+  t1->SetBranchStatus("BToKstll_lep1_isLowPt", 1);      t1->SetBranchAddress("BToKstll_lep1_isLowPt", &BToKstll_lep1_isLowPt);
+  t1->SetBranchStatus("BToKstll_lep2_isLowPt", 1);      t1->SetBranchAddress("BToKstll_lep2_isLowPt", &BToKstll_lep2_isLowPt);
+  t1->SetBranchStatus("BToKstll_lep2_isPFLep", 1);      t1->SetBranchAddress("BToKstll_lep2_isPFLep", &BToKstll_lep2_isPFLep);
   t1->SetBranchStatus("BToKstll_isLowPtEle", 1);        t1->SetBranchAddress("BToKstll_isLowPtEle", &BToKstll_isLowPtEle);  
   
   t1->SetBranchStatus("BToKstll_lep1_seedBDT_unbiased", 1);   t1->SetBranchAddress("BToKstll_lep1_seedBDT_unbiased", &BToKstll_lep1_seedBDT_unbiased);
@@ -515,6 +519,8 @@ int main(int argc, char **argv){
   TH1F* hBmass[7];
   TH1F* hBmass_llt[7];
   TH1F* hBmass_ltt[7];
+  TH1F* hBmass_l1l2_lowPt[7];
+  TH1F* hBmass_l2_lowPt[7];
   TH2F* BDTele1_vs_pTele1[7];
   TH2F* BDTele2_vs_pTele2[7];
   TH2F* BDTele2_vs_BDTele1[7];
@@ -565,6 +571,16 @@ int main(int argc, char **argv){
     hBmass_ltt[ij]->Sumw2();
     hBmass_ltt[ij]->SetLineColor(kRed);
     hBmass_ltt[ij]->SetLineWidth(2);
+
+    hBmass_l1l2_lowPt[ij] = new TH1F(Form("Bmass_l1l2_lowPt_%d", ij), "", 750, 0., 15.); // 75, 4.5, 6.);
+    hBmass_l1l2_lowPt[ij]->Sumw2();
+    hBmass_l1l2_lowPt[ij]->SetLineColor(kRed);
+    hBmass_l1l2_lowPt[ij]->SetLineWidth(2);
+
+    hBmass_l2_lowPt[ij] = new TH1F(Form("Bmass_l2_lowPt_%d", ij), "", 750, 0., 15.); // 75, 4.5, 6.);
+    hBmass_l2_lowPt[ij]->Sumw2();
+    hBmass_l2_lowPt[ij]->SetLineColor(kRed);
+    hBmass_l2_lowPt[ij]->SetLineWidth(2);
 
     hctxy[ij] = new TH1F(Form("hctxy_%d", ij), "", 1000, 0., 10.);
     hctxy[ij]->Sumw2();
@@ -650,6 +666,8 @@ int main(int argc, char **argv){
     int muon_tag_index_event = -1;
     int triplet_sel_index = -1;
     bool isllt = false;         
+    bool isl1l2_lowPt = false;
+    bool isl2_lowPt = false;
     bool goodTripletFound = false;
 
     //choose the best vtxCL candidate provided it survives the selections
@@ -681,6 +699,10 @@ int main(int argc, char **argv){
 	}
 
 	isllt = (iL == 1) ? false : true;
+
+	isl1l2_lowPt = bool(BToKstll_lep1_isLowPt[triplet_sel_index] == 1 && BToKstll_lep2_isLowPt[triplet_sel_index]== 1);
+	isl2_lowPt = bool(BToKstll_lep2_isLowPt[triplet_sel_index]== 1);
+
 	goodTripletFound = true;
 	break;
       }
@@ -809,7 +831,9 @@ int main(int argc, char **argv){
       hBmass[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
       if(isllt) hBmass_llt[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
       else hBmass_ltt[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
-      
+      if(isl1l2_lowPt) hBmass_l1l2_lowPt[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
+      if(isl2_lowPt) hBmass_l2_lowPt[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
+
       BDTele1_vs_pTele1[massBin]->Fill(BToKstll_lep1_pt[triplet_sel_index], BToKstll_lep1_seedBDT_unbiased[triplet_sel_index]);
       BDTele2_vs_pTele2[massBin]->Fill(BToKstll_lep2_pt[triplet_sel_index], BToKstll_lep2_seedBDT_unbiased[triplet_sel_index]);
       BDTele2_vs_BDTele1[massBin]->Fill(BToKstll_lep1_seedBDT_unbiased[triplet_sel_index], BToKstll_lep2_seedBDT_unbiased[triplet_sel_index]);
@@ -822,6 +846,8 @@ int main(int argc, char **argv){
     hBmass[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
     if(isllt) hBmass_llt[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
     else hBmass_ltt[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
+    if(isl1l2_lowPt) hBmass_l1l2_lowPt[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
+    if(isl2_lowPt) hBmass_l2_lowPt[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
     
     hAlpha[6]->Fill(BToKstll_B_cosAlpha[triplet_sel_index]);
     hCLVtx[6]->Fill(BToKstll_B_CL_vtx[triplet_sel_index]);
@@ -881,7 +907,9 @@ int main(int argc, char **argv){
     hBmass[ij]->Write(hBmass[ij]->GetName());
     hBmass_llt[ij]->Write(hBmass_llt[ij]->GetName());
     hBmass_ltt[ij]->Write(hBmass_ltt[ij]->GetName());
-    
+    hBmass_l1l2_lowPt[ij]->Write(hBmass_l1l2_lowPt[ij]->GetName());
+    hBmass_l2_lowPt[ij]->Write(hBmass_l2_lowPt[ij]->GetName());
+
     BDTele1_vs_pTele1[ij]->Write(BDTele1_vs_pTele1[ij]->GetName());
     BDTele2_vs_pTele2[ij]->Write(BDTele2_vs_pTele2[ij]->GetName());
     BDTele2_vs_BDTele1[ij]->Write(BDTele2_vs_BDTele1[ij]->GetName());


### PR DESCRIPTION
adding plot categories of Bmass for 
- both l1 and l2 = low Pt 
- only l2 = low Pt

these are subsamples of the inclusive plots llt
useful for plotting and understanding the contribution from low pt ele