### PR TITLE
PFCand and LT Bmass categories

### DIFF
--- a/NtupleProducer/macro/analyzeCharged_fastDATA_Kstll.cpp
+++ b/NtupleProducer/macro/analyzeCharged_fastDATA_Kstll.cpp
@@ -343,6 +343,10 @@ int main(int argc, char **argv){
   int BToKstll_lep2_isLowPt[kBToKstllMax];
   int BToKstll_lep2_isPFLep[kBToKstllMax];
   int BToKstll_isLowPtEle[kBToKstllMax];
+  int BToKstll_lep1_isPFCand[kBToKstllMax];
+  int BToKstll_lep2_isPFCand[kBToKstllMax];
+  int BToKstll_lep1_isLT[kBToKstllMax];
+  int BToKstll_lep2_isLT[kBToKstllMax];
   
   float BToKstll_lep1_seedBDT_unbiased[kBToKstllMax];
   float BToKstll_lep1_seedBDT_ptbiased[kBToKstllMax];
@@ -411,7 +415,13 @@ int main(int argc, char **argv){
   t1->SetBranchStatus("BToKstll_lep1_isLowPt", 1);      t1->SetBranchAddress("BToKstll_lep1_isLowPt", &BToKstll_lep1_isLowPt);
   t1->SetBranchStatus("BToKstll_lep2_isLowPt", 1);      t1->SetBranchAddress("BToKstll_lep2_isLowPt", &BToKstll_lep2_isLowPt);
   t1->SetBranchStatus("BToKstll_lep2_isPFLep", 1);      t1->SetBranchAddress("BToKstll_lep2_isPFLep", &BToKstll_lep2_isPFLep);
-  t1->SetBranchStatus("BToKstll_isLowPtEle", 1);        t1->SetBranchAddress("BToKstll_isLowPtEle", &BToKstll_isLowPtEle);  
+  t1->SetBranchStatus("BToKstll_isLowPtEle", 1);        t1->SetBranchAddress("BToKstll_isLowPtEle", &BToKstll_isLowPtEle);
+  
+  t1->SetBranchStatus("BToKstll_lep1_isPFCand", 1);      t1->SetBranchAddress("BToKstll_lep1_isPFCand", &BToKstll_lep1_isPFCand);
+  t1->SetBranchStatus("BToKstll_lep2_isPFCand", 1);      t1->SetBranchAddress("BToKstll_lep2_isPFCand", &BToKstll_lep2_isPFCand);
+
+  t1->SetBranchStatus("BToKstll_lep1_isLT", 1);      t1->SetBranchAddress("BToKstll_lep1_isLT", &BToKstll_lep1_isLT);
+  t1->SetBranchStatus("BToKstll_lep2_isLT", 1);      t1->SetBranchAddress("BToKstll_lep2_isLT", &BToKstll_lep2_isLT);
   
   t1->SetBranchStatus("BToKstll_lep1_seedBDT_unbiased", 1);   t1->SetBranchAddress("BToKstll_lep1_seedBDT_unbiased", &BToKstll_lep1_seedBDT_unbiased);
   t1->SetBranchStatus("BToKstll_lep1_seedBDT_ptbiased", 1);   t1->SetBranchAddress("BToKstll_lep1_seedBDT_ptbiased", &BToKstll_lep1_seedBDT_ptbiased);
@@ -521,6 +531,10 @@ int main(int argc, char **argv){
   TH1F* hBmass_ltt[7];
   TH1F* hBmass_l1l2_lowPt[7];
   TH1F* hBmass_l2_lowPt[7];
+  TH1F* hBmass_l1l2_PFCand[7];
+  TH1F* hBmass_l2_PFCand[7];
+  TH1F* hBmass_l1l2_LT[7];
+  TH1F* hBmass_l2_LT[7];
   TH2F* BDTele1_vs_pTele1[7];
   TH2F* BDTele2_vs_pTele2[7];
   TH2F* BDTele2_vs_BDTele1[7];
@@ -581,6 +595,26 @@ int main(int argc, char **argv){
     hBmass_l2_lowPt[ij]->Sumw2();
     hBmass_l2_lowPt[ij]->SetLineColor(kRed);
     hBmass_l2_lowPt[ij]->SetLineWidth(2);
+    
+    hBmass_l1l2_PFCand[ij] = new TH1F(Form("Bmass_l1l2_PFCand_%d", ij), "", 750, 0., 15.); // 75, 4.5, 6.);
+    hBmass_l1l2_PFCand[ij]->Sumw2();
+    hBmass_l1l2_PFCand[ij]->SetLineColor(kRed);
+    hBmass_l1l2_PFCand[ij]->SetLineWidth(2);
+    
+    hBmass_l2_PFCand[ij] = new TH1F(Form("Bmass_l2_PFCand_%d", ij), "", 750, 0., 15.); // 75, 4.5, 6.);
+    hBmass_l2_PFCand[ij]->Sumw2();
+    hBmass_l2_PFCand[ij]->SetLineColor(kRed);
+    hBmass_l2_PFCand[ij]->SetLineWidth(2);
+    
+    hBmass_l1l2_LT[ij] = new TH1F(Form("Bmass_l1l2_LT_%d", ij), "", 750, 0., 15.); // 75, 4.5, 6.);
+    hBmass_l1l2_LT[ij]->Sumw2();
+    hBmass_l1l2_LT[ij]->SetLineColor(kRed);
+    hBmass_l1l2_LT[ij]->SetLineWidth(2);
+    
+    hBmass_l2_LT[ij] = new TH1F(Form("Bmass_l2_LT_%d", ij), "", 750, 0., 15.); // 75, 4.5, 6.);
+    hBmass_l2_LT[ij]->Sumw2();
+    hBmass_l2_LT[ij]->SetLineColor(kRed);
+    hBmass_l2_LT[ij]->SetLineWidth(2);    
 
     hctxy[ij] = new TH1F(Form("hctxy_%d", ij), "", 1000, 0., 10.);
     hctxy[ij]->Sumw2();
@@ -668,6 +702,10 @@ int main(int argc, char **argv){
     bool isllt = false;         
     bool isl1l2_lowPt = false;
     bool isl2_lowPt = false;
+    bool isl1l2_PFCand = false;
+    bool isl2_PFCand = false;
+    bool isl1l2_LT = false;
+    bool isl2_LT = false;
     bool goodTripletFound = false;
 
     //choose the best vtxCL candidate provided it survives the selections
@@ -703,6 +741,12 @@ int main(int argc, char **argv){
 	isl1l2_lowPt = bool(BToKstll_lep1_isLowPt[triplet_sel_index] == 1 && BToKstll_lep2_isLowPt[triplet_sel_index]== 1);
 	isl2_lowPt = bool(BToKstll_lep2_isLowPt[triplet_sel_index]== 1);
 
+    isl1l2_PFCand = bool(BToKstll_lep1_isPFCand[triplet_sel_index] == 1 && BToKstll_lep2_isPFCand[triplet_sel_index]== 1);
+    isl2_PFCand = bool(BToKstll_lep2_isPFCand[triplet_sel_index]== 1);
+    
+    isl1l2_LT = bool(BToKstll_lep1_isLT[triplet_sel_index] == 1 && BToKstll_lep2_isLT[triplet_sel_index]== 1);
+    isl2_LT = bool(BToKstll_lep2_isLT[triplet_sel_index]== 1);
+    
 	goodTripletFound = true;
 	break;
       }
@@ -833,6 +877,10 @@ int main(int argc, char **argv){
       else hBmass_ltt[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
       if(isl1l2_lowPt) hBmass_l1l2_lowPt[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
       if(isl2_lowPt) hBmass_l2_lowPt[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
+      if(isl1l2_PFCand) hBmass_l1l2_PFCand[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
+      if(isl2_PFCand) hBmass_l2_PFCand[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
+      if(isl1l2_LT) hBmass_l1l2_LT[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
+      if(isl2_LT) hBmass_l2_LT[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
 
       BDTele1_vs_pTele1[massBin]->Fill(BToKstll_lep1_pt[triplet_sel_index], BToKstll_lep1_seedBDT_unbiased[triplet_sel_index]);
       BDTele2_vs_pTele2[massBin]->Fill(BToKstll_lep2_pt[triplet_sel_index], BToKstll_lep2_seedBDT_unbiased[triplet_sel_index]);
@@ -848,6 +896,10 @@ int main(int argc, char **argv){
     else hBmass_ltt[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
     if(isl1l2_lowPt) hBmass_l1l2_lowPt[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
     if(isl2_lowPt) hBmass_l2_lowPt[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
+    if(isl1l2_PFCand) hBmass_l1l2_PFCand[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
+    if(isl2_PFCand) hBmass_l2_PFCand[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
+    if(isl1l2_LT) hBmass_l1l2_LT[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
+    if(isl2_LT) hBmass_l2_LT[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
     
     hAlpha[6]->Fill(BToKstll_B_cosAlpha[triplet_sel_index]);
     hCLVtx[6]->Fill(BToKstll_B_CL_vtx[triplet_sel_index]);
@@ -909,6 +961,10 @@ int main(int argc, char **argv){
     hBmass_ltt[ij]->Write(hBmass_ltt[ij]->GetName());
     hBmass_l1l2_lowPt[ij]->Write(hBmass_l1l2_lowPt[ij]->GetName());
     hBmass_l2_lowPt[ij]->Write(hBmass_l2_lowPt[ij]->GetName());
+    hBmass_l1l2_PFCand[ij]->Write(hBmass_l1l2_PFCand[ij]->GetName());
+    hBmass_l2_PFCand[ij]->Write(hBmass_l2_PFCand[ij]->GetName());
+    hBmass_l1l2_LT[ij]->Write(hBmass_l1l2_LT[ij]->GetName());
+    hBmass_l2_LT[ij]->Write(hBmass_l2_LT[ij]->GetName());
 
     BDTele1_vs_pTele1[ij]->Write(BDTele1_vs_pTele1[ij]->GetName());
     BDTele2_vs_pTele2[ij]->Write(BDTele2_vs_pTele2[ij]->GetName());
@@ -923,4 +979,4 @@ int main(int argc, char **argv){
   }
   outMassHistos.Close();
 
-}  
+} 

--- a/NtupleProducer/macro/analyzeCharged_fastDATA_Kstll.cpp
+++ b/NtupleProducer/macro/analyzeCharged_fastDATA_Kstll.cpp
@@ -535,6 +535,8 @@ int main(int argc, char **argv){
   TH1F* hBmass_l2_PFCand[7];
   TH1F* hBmass_l1l2_LT[7];
   TH1F* hBmass_l2_LT[7];
+  TH1F* hBmass_l1l2_Track[7];
+  TH1F* hBmass_l2_Track[7];
   TH2F* BDTele1_vs_pTele1[7];
   TH2F* BDTele2_vs_pTele2[7];
   TH2F* BDTele2_vs_BDTele1[7];
@@ -614,7 +616,17 @@ int main(int argc, char **argv){
     hBmass_l2_LT[ij] = new TH1F(Form("Bmass_l2_LT_%d", ij), "", 750, 0., 15.); // 75, 4.5, 6.);
     hBmass_l2_LT[ij]->Sumw2();
     hBmass_l2_LT[ij]->SetLineColor(kRed);
-    hBmass_l2_LT[ij]->SetLineWidth(2);    
+    hBmass_l2_LT[ij]->SetLineWidth(2);
+
+    hBmass_l1l2_Track[ij] = new TH1F(Form("Bmass_l1l2_Track_%d", ij), "", 750, 0., 15.); // 75, 4.5, 6.);
+    hBmass_l1l2_Track[ij]->Sumw2();
+    hBmass_l1l2_Track[ij]->SetLineColor(kRed);
+    hBmass_l1l2_Track[ij]->SetLineWidth(2);
+    
+    hBmass_l2_Track[ij] = new TH1F(Form("Bmass_l2_Track_%d", ij), "", 750, 0., 15.); // 75, 4.5, 6.);
+    hBmass_l2_Track[ij]->Sumw2();
+    hBmass_l2_Track[ij]->SetLineColor(kRed);
+    hBmass_l2_Track[ij]->SetLineWidth(2);    
 
     hctxy[ij] = new TH1F(Form("hctxy_%d", ij), "", 1000, 0., 10.);
     hctxy[ij]->Sumw2();
@@ -881,6 +893,8 @@ int main(int argc, char **argv){
       if(isl2_PFCand) hBmass_l2_PFCand[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
       if(isl1l2_LT) hBmass_l1l2_LT[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
       if(isl2_LT) hBmass_l2_LT[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
+      if(isl1l2_PFCand || isl1l2_LT) hBmass_l1l2_Track[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
+      if(isl2_PFCand || isl2_LT) hBmass_l2_Track[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
 
       BDTele1_vs_pTele1[massBin]->Fill(BToKstll_lep1_pt[triplet_sel_index], BToKstll_lep1_seedBDT_unbiased[triplet_sel_index]);
       BDTele2_vs_pTele2[massBin]->Fill(BToKstll_lep2_pt[triplet_sel_index], BToKstll_lep2_seedBDT_unbiased[triplet_sel_index]);
@@ -900,6 +914,8 @@ int main(int argc, char **argv){
     if(isl2_PFCand) hBmass_l2_PFCand[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
     if(isl1l2_LT) hBmass_l1l2_LT[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
     if(isl2_LT) hBmass_l2_LT[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
+    if(isl1l2_PFCand || isl1l2_LT) hBmass_l1l2_Track[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
+    if(isl2_PFCand || isl2_LT) hBmass_l2_Track[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
     
     hAlpha[6]->Fill(BToKstll_B_cosAlpha[triplet_sel_index]);
     hCLVtx[6]->Fill(BToKstll_B_CL_vtx[triplet_sel_index]);
@@ -965,6 +981,8 @@ int main(int argc, char **argv){
     hBmass_l2_PFCand[ij]->Write(hBmass_l2_PFCand[ij]->GetName());
     hBmass_l1l2_LT[ij]->Write(hBmass_l1l2_LT[ij]->GetName());
     hBmass_l2_LT[ij]->Write(hBmass_l2_LT[ij]->GetName());
+    hBmass_l1l2_Track[ij]->Write(hBmass_l1l2_Track[ij]->GetName());
+    hBmass_l2_Track[ij]->Write(hBmass_l2_Track[ij]->GetName());
 
     BDTele1_vs_pTele1[ij]->Write(BDTele1_vs_pTele1[ij]->GetName());
     BDTele2_vs_pTele2[ij]->Write(BDTele2_vs_pTele2[ij]->GetName());

--- a/NtupleProducer/macro/analyzeCharged_fastDATA_Kstll.cpp
+++ b/NtupleProducer/macro/analyzeCharged_fastDATA_Kstll.cpp
@@ -1,4 +1,4 @@
-//g++ -Wall -o analyzeCharged_fastDATA_Kstll `root-config --cflags --glibs` -lRooFitCore analyzeCharged_fastDATA_Kstll.cpp
+-//g++ -Wall -o analyzeCharged_fastDATA_Kstll `root-config --cflags --glibs` -lRooFitCore analyzeCharged_fastDATA_Kstll.cpp
 
 //./analyzeCharged_fastDATA_Kstll --isEle (0,1) --dataset (-1, runA, runB, runD, MC) --run (1,2,3,..., -1) --typeSelection (tightCB) --ntupleList (list.txt) --JOBid (1,2..) --outputFolder ("outfolder") --nMaxEvents (-1, N) --saveSelectedNTU (1,0) --outSelectedNTU (path for selected ntuples) --testFile ("path")
 
@@ -519,6 +519,12 @@ int main(int argc, char **argv){
   TH1F* hKaonpt[7];
   TH1F* hLep1pt[7];
   TH1F* hLep2pt[7];
+  TH1F* hLep1pt_PFCand[7];
+  TH1F* hLep2pt_PFCand[7];
+  TH1F* hLep1pt_LT[7];
+  TH1F* hLep2pt_LT[7];
+  TH1F* hLep1pt_Track[7];
+  TH1F* hLep2pt_Track[7];  
   TH1F* hLep1pt_EB[7];
   TH1F* hLep2pt_EB[7];
   TH1F* hLep1pt_EE[7];
@@ -636,17 +642,47 @@ int main(int argc, char **argv){
     hKaonpt[ij] = new TH1F(Form("hKaonpt_%d", ij), "", 100, 0., 10.);
     hKaonpt[ij]->Sumw2();
     hKaonpt[ij]->SetLineColor(kRed);
-    hKaonpt[ij]->SetLineWidth(2);
-
+    hKaonpt[ij]->SetLineWidth(2);    
+    
     hLep1pt[ij] = new TH1F(Form("hLep1pt_%d", ij), "", 100, 0., 10.);
     hLep1pt[ij]->Sumw2();
     hLep1pt[ij]->SetLineColor(kRed);
     hLep1pt[ij]->SetLineWidth(2);
+    
+    hLep1pt_PFCand[ij] = new TH1F(Form("hLep1pt_PFCand_%d", ij), "", 100, 0., 10.);
+    hLep1pt_PFCand[ij]->Sumw2();
+    hLep1pt_PFCand[ij]->SetLineColor(kRed);
+    hLep1pt_PFCand[ij]->SetLineWidth(2);
+
+    hLep1pt_LT[ij] = new TH1F(Form("hLep1pt_LT_%d", ij), "", 100, 0., 10.);
+    hLep1pt_LT[ij]->Sumw2();
+    hLep1pt_LT[ij]->SetLineColor(kRed);
+    hLep1pt_LT[ij]->SetLineWidth(2);
+
+    hLep1pt_Track[ij] = new TH1F(Form("hLep1pt_Track_%d", ij), "", 100, 0., 10.);
+    hLep1pt_Track[ij]->Sumw2();
+    hLep1pt_Track[ij]->SetLineColor(kRed);
+    hLep1pt_Track[ij]->SetLineWidth(2);    
 
     hLep2pt[ij] = new TH1F(Form("hLep2pt_%d", ij), "", 100, 0., 10.);
     hLep2pt[ij]->Sumw2();
     hLep2pt[ij]->SetLineColor(kRed);
     hLep2pt[ij]->SetLineWidth(2);
+    
+    hLep2pt_PFCand[ij] = new TH1F(Form("hLep2pt_PFCand_%d", ij), "", 100, 0., 10.);
+    hLep2pt_PFCand[ij]->Sumw2();
+    hLep2pt_PFCand[ij]->SetLineColor(kRed);
+    hLep2pt_PFCand[ij]->SetLineWidth(2);
+
+    hLep2pt_LT[ij] = new TH1F(Form("hLep2pt_LT_%d", ij), "", 100, 0., 10.);
+    hLep2pt_LT[ij]->Sumw2();
+    hLep2pt_LT[ij]->SetLineColor(kRed);
+    hLep2pt_LT[ij]->SetLineWidth(2);
+
+    hLep2pt_Track[ij] = new TH1F(Form("hLep2pt_Track_%d", ij), "", 100, 0., 10.);
+    hLep2pt_Track[ij]->Sumw2();
+    hLep2pt_Track[ij]->SetLineColor(kRed);
+    hLep2pt_Track[ij]->SetLineWidth(2);    
 
     //
     hLep1pt_EB[ij] = new TH1F(Form("hLep1pt_EB_%d", ij), "", 100, 0., 10.);
@@ -715,8 +751,10 @@ int main(int argc, char **argv){
     bool isl1l2_lowPt = false;
     bool isl2_lowPt = false;
     bool isl1l2_PFCand = false;
+    bool isl1_PFCand = false;
     bool isl2_PFCand = false;
     bool isl1l2_LT = false;
+    bool isl1_LT = false;
     bool isl2_LT = false;
     bool goodTripletFound = false;
 
@@ -754,9 +792,11 @@ int main(int argc, char **argv){
 	isl2_lowPt = bool(BToKstll_lep2_isLowPt[triplet_sel_index]== 1);
 
     isl1l2_PFCand = bool(BToKstll_lep1_isPFCand[triplet_sel_index] == 1 && BToKstll_lep2_isPFCand[triplet_sel_index]== 1);
+    isl1_PFCand = bool(BToKstll_lep1_isPFCand[triplet_sel_index]== 1);
     isl2_PFCand = bool(BToKstll_lep2_isPFCand[triplet_sel_index]== 1);
     
     isl1l2_LT = bool(BToKstll_lep1_isLT[triplet_sel_index] == 1 && BToKstll_lep2_isLT[triplet_sel_index]== 1);
+    isl1_LT = bool(BToKstll_lep1_isLT[triplet_sel_index]== 1);
     isl2_LT = bool(BToKstll_lep2_isLT[triplet_sel_index]== 1);
     
 	goodTripletFound = true;
@@ -890,11 +930,23 @@ int main(int argc, char **argv){
       if(isl1l2_lowPt) hBmass_l1l2_lowPt[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
       if(isl2_lowPt) hBmass_l2_lowPt[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
       if(isl1l2_PFCand) hBmass_l1l2_PFCand[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
-      if(isl2_PFCand) hBmass_l2_PFCand[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
+      if(isl1_PFCand) hLep1pt_PFCand[massBin]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
+      if(isl2_PFCand){ 
+        hBmass_l2_PFCand[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
+        hLep2pt_PFCand[massBin]->Fill(BToKstll_lep2_pt[triplet_sel_index]);
+      }
       if(isl1l2_LT) hBmass_l1l2_LT[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
-      if(isl2_LT) hBmass_l2_LT[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
+      if(isl1_LT) hLep1pt_LT[massBin]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
+      if(isl2_LT){
+        hBmass_l2_LT[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
+        hLep2pt_LT[massBin]->Fill(BToKstll_lep2_pt[triplet_sel_index]);
+      }
       if(isl1l2_PFCand || isl1l2_LT) hBmass_l1l2_Track[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
-      if(isl2_PFCand || isl2_LT) hBmass_l2_Track[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
+      if(isl1_PFCand || isl1_LT) hLep1pt_Track[massBin]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
+      if(isl2_PFCand || isl2_LT){
+        hBmass_l2_Track[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
+        hLep2pt_Track[massBin]->Fill(BToKstll_lep2_pt[triplet_sel_index]);
+      }
 
       BDTele1_vs_pTele1[massBin]->Fill(BToKstll_lep1_pt[triplet_sel_index], BToKstll_lep1_seedBDT_unbiased[triplet_sel_index]);
       BDTele2_vs_pTele2[massBin]->Fill(BToKstll_lep2_pt[triplet_sel_index], BToKstll_lep2_seedBDT_unbiased[triplet_sel_index]);
@@ -911,12 +963,23 @@ int main(int argc, char **argv){
     if(isl1l2_lowPt) hBmass_l1l2_lowPt[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
     if(isl2_lowPt) hBmass_l2_lowPt[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
     if(isl1l2_PFCand) hBmass_l1l2_PFCand[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
-    if(isl2_PFCand) hBmass_l2_PFCand[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
+    if(isl1_PFCand) hLep1pt_PFCand[6]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
+    if(isl2_PFCand){
+        hBmass_l2_PFCand[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
+        hLep2pt_PFCand[6]->Fill(BToKstll_lep2_pt[triplet_sel_index]);
+    }
     if(isl1l2_LT) hBmass_l1l2_LT[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
-    if(isl2_LT) hBmass_l2_LT[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
+    if(isl1_LT) hLep1pt_LT[6]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
+    if(isl2_LT){
+        hBmass_l2_LT[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
+        hLep2pt_LT[6]->Fill(BToKstll_lep2_pt[triplet_sel_index]);
+    }
     if(isl1l2_PFCand || isl1l2_LT) hBmass_l1l2_Track[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
-    if(isl2_PFCand || isl2_LT) hBmass_l2_Track[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
-    
+    if(isl1_PFCand || isl1_LT) hLep1pt_Track[6]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
+    if(isl2_PFCand || isl2_LT){
+        hBmass_l2_Track[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
+        hLep2pt_Track[6]->Fill(BToKstll_lep2_pt[triplet_sel_index]);
+    }
     hAlpha[6]->Fill(BToKstll_B_cosAlpha[triplet_sel_index]);
     hCLVtx[6]->Fill(BToKstll_B_CL_vtx[triplet_sel_index]);
     hDCASig[6]->Fill(BToKstll_kaon_DCASig[triplet_sel_index]);
@@ -961,7 +1024,13 @@ int main(int argc, char **argv){
     hctxy[ij]->Write(hctxy[ij]->GetName());
     hKaonpt[ij]->Write(hKaonpt[ij]->GetName());
     hLep1pt[ij]->Write(hLep1pt[ij]->GetName());
+    hLep1pt_PFCand[ij]->Write(hLep1pt_PFCand[ij]->GetName());
+    hLep1pt_LT[ij]->Write(hLep1pt_LT[ij]->GetName());
+    hLep1pt_Track[ij]->Write(hLep1pt_Track[ij]->GetName());
     hLep2pt[ij]->Write(hLep2pt[ij]->GetName());
+    hLep2pt_PFCand[ij]->Write(hLep2pt_PFCand[ij]->GetName());
+    hLep2pt_LT[ij]->Write(hLep2pt_LT[ij]->GetName());
+    hLep2pt_Track[ij]->Write(hLep2pt_Track[ij]->GetName());
     hLep1pt_EB[ij]->Write(hLep1pt_EB[ij]->GetName());
     hLep1pt_EE[ij]->Write(hLep1pt_EE[ij]->GetName());
     hLep2pt_EB[ij]->Write(hLep2pt_EB[ij]->GetName());


### PR DESCRIPTION
Add in the analyzer plot categories of Bmass for

- both l1 and l2 = PFCand

- only l2 = PFCand

- both l1 and l2 = LT

- only l2 = LT