### PR TITLE
Classification of triplets as llt

### DIFF
--- a/NtupleProducer/macro/analyzeCharged_fastDATA_Kstll.cpp
+++ b/NtupleProducer/macro/analyzeCharged_fastDATA_Kstll.cpp
@@ -521,6 +521,8 @@ int main(int argc, char **argv){
   TH1F* hKaonpt[7];
   TH1F* hLep1pt[7];
   TH1F* hLep2pt[7];
+  TH1F* hLep1pt_lowPt[7];
+  TH1F* hLep2pt_lowPt[7];
   TH1F* hLep1pt_PFCand[7];
   TH1F* hLep2pt_PFCand[7];
   TH1F* hLep1pt_LT[7];
@@ -650,6 +652,11 @@ int main(int argc, char **argv){
     hLep1pt[ij]->Sumw2();
     hLep1pt[ij]->SetLineColor(kRed);
     hLep1pt[ij]->SetLineWidth(2);
+
+    hLep1pt_lowPt[ij] = new TH1F(Form("hLep1pt_lowPt_%d", ij), "", 100, 0., 10.);
+    hLep1pt_lowPt[ij]->Sumw2();
+    hLep1pt_lowPt[ij]->SetLineColor(kRed);
+    hLep1pt_lowPt[ij]->SetLineWidth(2);
     
     hLep1pt_PFCand[ij] = new TH1F(Form("hLep1pt_PFCand_%d", ij), "", 100, 0., 10.);
     hLep1pt_PFCand[ij]->Sumw2();
@@ -670,6 +677,11 @@ int main(int argc, char **argv){
     hLep2pt[ij]->Sumw2();
     hLep2pt[ij]->SetLineColor(kRed);
     hLep2pt[ij]->SetLineWidth(2);
+    
+    hLep2pt_lowPt[ij] = new TH1F(Form("hLep2pt_lowPt_%d", ij), "", 100, 0., 10.);
+    hLep2pt_lowPt[ij]->Sumw2();
+    hLep2pt_lowPt[ij]->SetLineColor(kRed);
+    hLep2pt_lowPt[ij]->SetLineWidth(2);    
     
     hLep2pt_PFCand[ij] = new TH1F(Form("hLep2pt_PFCand_%d", ij), "", 100, 0., 10.);
     hLep2pt_PFCand[ij]->Sumw2();
@@ -751,6 +763,7 @@ int main(int argc, char **argv){
     int triplet_sel_index = -1;
     bool isllt = false;         
     bool isl1l2_lowPt = false;
+    bool isl1_lowPt = false;
     bool isl2_lowPt = false;
     bool isl1l2_PFCand = false;
     bool isl1_PFCand = false;
@@ -791,7 +804,8 @@ int main(int argc, char **argv){
 	isllt = (iL == 1) ? false : true;
 
 	isl1l2_lowPt = bool(BToKstll_lep1_isLowPt[triplet_sel_index] == 1 && BToKstll_lep2_isLowPt[triplet_sel_index]== 1);
-	isl2_lowPt = bool(BToKstll_lep2_isLowPt[triplet_sel_index]== 1);
+    isl1_lowPt = bool(BToKstll_lep1_isLowPt[triplet_sel_index]== 1);
+    isl2_lowPt = bool(BToKstll_lep2_isLowPt[triplet_sel_index]== 1);
 
     isl1l2_PFCand = bool(BToKstll_lep1_isPFCand[triplet_sel_index] == 1 && BToKstll_lep2_isPFCand[triplet_sel_index]== 1);
     isl1_PFCand = bool(BToKstll_lep1_isPFCand[triplet_sel_index]== 1);
@@ -930,7 +944,11 @@ int main(int argc, char **argv){
       if(isllt) hBmass_llt[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
       else hBmass_not_llt[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
       if(isl1l2_lowPt) hBmass_l1l2_lowPt[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
-      if(isl2_lowPt) hBmass_l2_lowPt[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
+      if(isl1_lowPt) hLep1pt_lowPt[massBin]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
+      if(isl2_lowPt){
+        hBmass_l2_lowPt[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
+        hLep2pt_lowPt[massBin]->Fill(BToKstll_lep2_pt[triplet_sel_index]);
+      }
       if(isl1l2_PFCand) hBmass_l1l2_PFCand[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
       if(isl1_PFCand) hLep1pt_PFCand[massBin]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
       if(isl2_PFCand){ 
@@ -963,7 +981,11 @@ int main(int argc, char **argv){
     if(isllt) hBmass_llt[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
     else hBmass_not_llt[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
     if(isl1l2_lowPt) hBmass_l1l2_lowPt[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
-    if(isl2_lowPt) hBmass_l2_lowPt[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
+    if(isl1_lowPt) hLep1pt_lowPt[6]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
+    if(isl2_lowPt){
+        hBmass_l2_lowPt[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
+        hLep2pt_lowPt[6]->Fill(BToKstll_lep2_pt[triplet_sel_index]);
+    }
     if(isl1l2_PFCand) hBmass_l1l2_PFCand[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
     if(isl1_PFCand) hLep1pt_PFCand[6]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
     if(isl2_PFCand){
@@ -1026,10 +1048,12 @@ int main(int argc, char **argv){
     hctxy[ij]->Write(hctxy[ij]->GetName());
     hKaonpt[ij]->Write(hKaonpt[ij]->GetName());
     hLep1pt[ij]->Write(hLep1pt[ij]->GetName());
+    hLep1pt_lowPt[ij]->Write(hLep1pt_lowPt[ij]->GetName());
     hLep1pt_PFCand[ij]->Write(hLep1pt_PFCand[ij]->GetName());
     hLep1pt_LT[ij]->Write(hLep1pt_LT[ij]->GetName());
     hLep1pt_Track[ij]->Write(hLep1pt_Track[ij]->GetName());
     hLep2pt[ij]->Write(hLep2pt[ij]->GetName());
+    hLep2pt_lowPt[ij]->Write(hLep2pt_lowPt[ij]->GetName());
     hLep2pt_PFCand[ij]->Write(hLep2pt_PFCand[ij]->GetName());
     hLep2pt_LT[ij]->Write(hLep2pt_LT[ij]->GetName());
     hLep2pt_Track[ij]->Write(hLep2pt_Track[ij]->GetName());

--- a/NtupleProducer/macro/analyzeCharged_fastDATA_Kstll.cpp
+++ b/NtupleProducer/macro/analyzeCharged_fastDATA_Kstll.cpp
@@ -784,7 +784,7 @@ int main(int argc, char **argv){
 	muon_tag_index_event = Muon_tag_index->at(triplet_sel_index);
 	
 	if( iL == 0 && (BToKstll_lep1_isPFLep[triplet_sel_index] != 1 || BToKstll_lep2_isPFLep[triplet_sel_index] != 1) ) continue;
-	else if( iL == 1 && (BToKstll_lep1_isPFLep[triplet_sel_index] == 1 || BToKstll_lep2_isPFLep[triplet_sel_index] == 1) ) continue;
+	else if( iL == 1 && (BToKstll_lep1_isPFLep[triplet_sel_index] == 1 && BToKstll_lep2_isPFLep[triplet_sel_index] == 1) ) continue;
 	
 	if(muon_tag_index_event == -1 || triplet_sel_index == -1) continue;
 	if(dataset == "MC" && Muon_probe_index == -1) continue;

--- a/NtupleProducer/macro/analyzeCharged_fastDATA_Kstll.cpp
+++ b/NtupleProducer/macro/analyzeCharged_fastDATA_Kstll.cpp
@@ -1,4 +1,4 @@
--//g++ -Wall -o analyzeCharged_fastDATA_Kstll `root-config --cflags --glibs` -lRooFitCore analyzeCharged_fastDATA_Kstll.cpp
+//g++ -Wall -o analyzeCharged_fastDATA_Kstll `root-config --cflags --glibs` -lRooFitCore analyzeCharged_fastDATA_Kstll.cpp
 
 //./analyzeCharged_fastDATA_Kstll --isEle (0,1) --dataset (-1, runA, runB, runD, MC) --run (1,2,3,..., -1) --typeSelection (tightCB) --ntupleList (list.txt) --JOBid (1,2..) --outputFolder ("outfolder") --nMaxEvents (-1, N) --saveSelectedNTU (1,0) --outSelectedNTU (path for selected ntuples) --testFile ("path")
 
@@ -341,6 +341,7 @@ int main(int argc, char **argv){
 
   int BToKstll_lep1_isLowPt[kBToKstllMax];
   int BToKstll_lep2_isLowPt[kBToKstllMax];
+  int BToKstll_lep1_isPFLep[kBToKstllMax];
   int BToKstll_lep2_isPFLep[kBToKstllMax];
   int BToKstll_isLowPtEle[kBToKstllMax];
   int BToKstll_lep1_isPFCand[kBToKstllMax];
@@ -414,6 +415,7 @@ int main(int argc, char **argv){
   
   t1->SetBranchStatus("BToKstll_lep1_isLowPt", 1);      t1->SetBranchAddress("BToKstll_lep1_isLowPt", &BToKstll_lep1_isLowPt);
   t1->SetBranchStatus("BToKstll_lep2_isLowPt", 1);      t1->SetBranchAddress("BToKstll_lep2_isLowPt", &BToKstll_lep2_isLowPt);
+  t1->SetBranchStatus("BToKstll_lep1_isPFLep", 1);      t1->SetBranchAddress("BToKstll_lep1_isPFLep", &BToKstll_lep1_isPFLep);
   t1->SetBranchStatus("BToKstll_lep2_isPFLep", 1);      t1->SetBranchAddress("BToKstll_lep2_isPFLep", &BToKstll_lep2_isPFLep);
   t1->SetBranchStatus("BToKstll_isLowPtEle", 1);        t1->SetBranchAddress("BToKstll_isLowPtEle", &BToKstll_isLowPtEle);
   
@@ -534,7 +536,7 @@ int main(int argc, char **argv){
   TH2F* hllRefitMass_vs_Bmass[7];
   TH1F* hBmass[7];
   TH1F* hBmass_llt[7];
-  TH1F* hBmass_ltt[7];
+  TH1F* hBmass_not_llt[7];
   TH1F* hBmass_l1l2_lowPt[7];
   TH1F* hBmass_l2_lowPt[7];
   TH1F* hBmass_l1l2_PFCand[7];
@@ -589,10 +591,10 @@ int main(int argc, char **argv){
     hBmass_llt[ij]->SetLineColor(kRed);
     hBmass_llt[ij]->SetLineWidth(2);
 
-    hBmass_ltt[ij] = new TH1F(Form("Bmass_ltt_%d", ij), "", 750, 0., 15.); // 75, 4.5, 6.);
-    hBmass_ltt[ij]->Sumw2();
-    hBmass_ltt[ij]->SetLineColor(kRed);
-    hBmass_ltt[ij]->SetLineWidth(2);
+    hBmass_not_llt[ij] = new TH1F(Form("Bmass_not_llt_%d", ij), "", 750, 0., 15.); // 75, 4.5, 6.);
+    hBmass_not_llt[ij]->Sumw2();
+    hBmass_not_llt[ij]->SetLineColor(kRed);
+    hBmass_not_llt[ij]->SetLineWidth(2);
 
     hBmass_l1l2_lowPt[ij] = new TH1F(Form("Bmass_l1l2_lowPt_%d", ij), "", 750, 0., 15.); // 75, 4.5, 6.);
     hBmass_l1l2_lowPt[ij]->Sumw2();
@@ -768,8 +770,8 @@ int main(int argc, char **argv){
 	triplet_sel_index = BToKstll_order_index->at(iP);
 	muon_tag_index_event = Muon_tag_index->at(triplet_sel_index);
 	
-	if(iL == 0 && BToKstll_lep2_isPFLep[triplet_sel_index] != 1) continue;
-	else if(iL == 1 && BToKstll_lep2_isPFLep[triplet_sel_index] == 1) continue;
+	if( iL == 0 && (BToKstll_lep1_isPFLep[triplet_sel_index] != 1 || BToKstll_lep2_isPFLep[triplet_sel_index] != 1) ) continue;
+	else if( iL == 1 && (BToKstll_lep1_isPFLep[triplet_sel_index] == 1 || BToKstll_lep2_isPFLep[triplet_sel_index] == 1) ) continue;
 	
 	if(muon_tag_index_event == -1 || triplet_sel_index == -1) continue;
 	if(dataset == "MC" && Muon_probe_index == -1) continue;
@@ -926,7 +928,7 @@ int main(int argc, char **argv){
       hllRefitMass_vs_Bmass[massBin]->Fill(BToKstll_B_mass[triplet_sel_index], llInvRefitMass);
       hBmass[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
       if(isllt) hBmass_llt[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
-      else hBmass_ltt[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
+      else hBmass_not_llt[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
       if(isl1l2_lowPt) hBmass_l1l2_lowPt[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
       if(isl2_lowPt) hBmass_l2_lowPt[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
       if(isl1l2_PFCand) hBmass_l1l2_PFCand[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
@@ -959,7 +961,7 @@ int main(int argc, char **argv){
     hllRefitMass_vs_Bmass[6]->Fill(BToKstll_B_mass[triplet_sel_index], llInvRefitMass);
     hBmass[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
     if(isllt) hBmass_llt[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
-    else hBmass_ltt[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
+    else hBmass_not_llt[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
     if(isl1l2_lowPt) hBmass_l1l2_lowPt[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
     if(isl2_lowPt) hBmass_l2_lowPt[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
     if(isl1l2_PFCand) hBmass_l1l2_PFCand[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
@@ -1043,7 +1045,7 @@ int main(int argc, char **argv){
     hllRefitMass_vs_Bmass[ij]->Write(hllRefitMass_vs_Bmass[ij]->GetName());
     hBmass[ij]->Write(hBmass[ij]->GetName());
     hBmass_llt[ij]->Write(hBmass_llt[ij]->GetName());
-    hBmass_ltt[ij]->Write(hBmass_ltt[ij]->GetName());
+    hBmass_not_llt[ij]->Write(hBmass_not_llt[ij]->GetName());
     hBmass_l1l2_lowPt[ij]->Write(hBmass_l1l2_lowPt[ij]->GetName());
     hBmass_l2_lowPt[ij]->Write(hBmass_l2_lowPt[ij]->GetName());
     hBmass_l1l2_PFCand[ij]->Write(hBmass_l1l2_PFCand[ij]->GetName());
@@ -1066,4 +1068,4 @@ int main(int argc, char **argv){
   }
   outMassHistos.Close();
 
-} 
+}  

--- a/NtupleProducer/macro/fitBmass_fromHistos.C
+++ b/NtupleProducer/macro/fitBmass_fromHistos.C
@@ -71,11 +71,11 @@ void fitBmass_fromHistos(int isEleFinalState, std::string inFile){
 
   TH1F* h_Bmass[7];
   TH1F* h_Bmass_llt[7];
-  TH1F* h_Bmass_ltt[7];
+  TH1F* h_Bmass_not_llt[7];
   for(int ij=0; ij<7; ++ij){
     h_Bmass[ij] = (TH1F*)inF->Get(Form("Bmass_%d", ij))->Clone(Form("h_Bmass_%d", ij));
     h_Bmass_llt[ij] = (TH1F*)inF->Get(Form("Bmass_llt_%d", ij))->Clone(Form("h_Bmass_llt_%d", ij));
-    h_Bmass_ltt[ij] = (TH1F*)inF->Get(Form("Bmass_ltt_%d", ij))->Clone(Form("h_Bmass_ltt_%d", ij));
+    h_Bmass_not_llt[ij] = (TH1F*)inF->Get(Form("Bmass_not_llt_%d", ij))->Clone(Form("h_Bmass_not_llt_%d", ij));
     //    h_Bmass[ij]->GetXaxis()->SetRangeUser(4.5, 6.);
   }//loop
 
@@ -118,7 +118,7 @@ void fitBmass_fromHistos(int isEleFinalState, std::string inFile){
     
     RooDataHist hBMass("hBMass", "hBMass", *w.var("x"), Import(*(h_Bmass[ij])));
     RooDataHist hBMass_llt("hBMass_llt", "hBMass_llt", *w.var("x"), Import(*(h_Bmass_llt[ij])));
-    RooDataHist hBMass_ltt("hBMass_ltt", "hBMass_ltt", *w.var("x"), Import(*(h_Bmass_ltt[ij])));
+    RooDataHist hBMass_not_llt("hBMass_not_llt", "hBMass_not_llt", *w.var("x"), Import(*(h_Bmass_not_llt[ij])));
     w.Print();
 
     RooFitResult * r = model->fitTo(hBMass, Minimizer("Minuit2"),Save(true));
@@ -140,7 +140,7 @@ void fitBmass_fromHistos(int isEleFinalState, std::string inFile){
     model->plotOn(plot, Components("modelb"),LineStyle(kDashed));
     model->plotOn(plot, Components("smodel"),LineColor(kRed));
     hBMass_llt.plotOn(plot,LineColor(kGreen+2),MarkerColor(kGreen+2)) ;
-    hBMass_ltt.plotOn(plot,LineColor(kViolet),MarkerColor(kViolet)) ;
+    hBMass_not_llt.plotOn(plot,LineColor(kViolet),MarkerColor(kViolet)) ;
     chi2[ij] = plot->chiSquare();
 
     RooRealVar* parS = (RooRealVar*) r->floatParsFinal().find("nsignal");
@@ -214,5 +214,4 @@ void fitBmass_fromHistos(int isEleFinalState, std::string inFile){
 	      << " chi2 = " << chi2[ij] << std::endl;
   }
 
-}
-
+} 


### PR DESCRIPTION
Previous analyzer classified as llt triplets with BToKstll_lep2_isPFLep==1 as lep1 could only be PFLep.
Analyzer is now updated since lep1 can also be lowPt, PFCand, and LT.