### PR TITLE
Priority and components

### DIFF
--- a/NtupleProducer/macro/analyzeCharged_fastDATA_Kstll.cpp
+++ b/NtupleProducer/macro/analyzeCharged_fastDATA_Kstll.cpp
@@ -775,7 +775,7 @@ int main(int argc, char **argv){
 
     //choose the best vtxCL candidate provided it survives the selections
     //priority is given to the llt triplets in case of LTT
-    for(int iL=0; iL<2; ++iL){
+    for(int iL=0; iL<3; ++iL){
       if(goodTripletFound) break;
 
       for(unsigned int iP = 0; iP < BToKstll_order_index->size(); ++iP){	
@@ -784,7 +784,9 @@ int main(int argc, char **argv){
 	muon_tag_index_event = Muon_tag_index->at(triplet_sel_index);
 	
 	if( iL == 0 && (BToKstll_lep1_isPFLep[triplet_sel_index] != 1 || BToKstll_lep2_isPFLep[triplet_sel_index] != 1) ) continue;
-	else if( iL == 1 && (BToKstll_lep1_isPFLep[triplet_sel_index] == 1 && BToKstll_lep2_isPFLep[triplet_sel_index] == 1) ) continue;
+	else if( iL == 1 && ( (BToKstll_lep1_isPFLep[triplet_sel_index] == 1 && BToKstll_lep2_isPFLep[triplet_sel_index] == 1) 
+                         || (BToKstll_lep1_isPFLep[triplet_sel_index] != 1 && BToKstll_lep2_isPFLep[triplet_sel_index] != 1) ) ) continue;
+    else if( iL == 2 && (BToKstll_lep1_isPFLep[triplet_sel_index] == 1 || BToKstll_lep2_isPFLep[triplet_sel_index] == 1) ) continue;
 	
 	if(muon_tag_index_event == -1 || triplet_sel_index == -1) continue;
 	if(dataset == "MC" && Muon_probe_index == -1) continue;
@@ -801,7 +803,7 @@ int main(int argc, char **argv){
 	  if(BToKstll_B_Lxy[triplet_sel_index] < 6.) continue;
 	}
 
-	isllt = (iL == 1) ? false : true;
+	isllt = (iL == 0) ? true : false;
 
 	isl1l2_lowPt = bool(BToKstll_lep1_isLowPt[triplet_sel_index] == 1 && BToKstll_lep2_isLowPt[triplet_sel_index]== 1);
     isl1_lowPt = bool(BToKstll_lep1_isLowPt[triplet_sel_index]== 1);
@@ -1092,4 +1094,4 @@ int main(int argc, char **argv){
   }
   outMassHistos.Close();
 
-}  
+} 

--- a/NtupleProducer/macro/fitBmass_fromHistos.C
+++ b/NtupleProducer/macro/fitBmass_fromHistos.C
@@ -71,11 +71,19 @@ void fitBmass_fromHistos(int isEleFinalState, std::string inFile){
 
   TH1F* h_Bmass[7];
   TH1F* h_Bmass_llt[7];
-  TH1F* h_Bmass_not_llt[7];
+  TH1F* h_Bmass_lep2_isNotPFLep[7];
+  TH1F* h_Bmass_lep12_areNotPFLep[7];
+  
   for(int ij=0; ij<7; ++ij){
-    h_Bmass[ij] = (TH1F*)inF->Get(Form("Bmass_%d", ij))->Clone(Form("h_Bmass_%d", ij));
+    
+    h_Bmass[ij] = (TH1F*)inF->Get(Form("Bmass_%d", ij))->Clone(Form("h_Bmass_%d", ij));    
     h_Bmass_llt[ij] = (TH1F*)inF->Get(Form("Bmass_llt_%d", ij))->Clone(Form("h_Bmass_llt_%d", ij));
-    h_Bmass_not_llt[ij] = (TH1F*)inF->Get(Form("Bmass_not_llt_%d", ij))->Clone(Form("h_Bmass_not_llt_%d", ij));
+    
+    if(isEleFinalState) h_Bmass_lep2_isNotPFLep[ij] = (TH1F*)inF->Get(Form("Bmass_l2_lowPt_%d", ij))->Clone(Form("h_Bmass_lep2_isNotPFLep_%d", ij));
+    else h_Bmass_lep2_isNotPFLep[ij] = (TH1F*)inF->Get(Form("Bmass_l2_Track_%d", ij))->Clone(Form("h_Bmass_lep2_isNotPFLep_%d", ij));
+    
+    if(isEleFinalState) h_Bmass_lep12_areNotPFLep[ij] = (TH1F*)inF->Get(Form("Bmass_l1l2_lowPt_%d", ij))->Clone(Form("h_Bmass_lep12_areNotPFLep_%d", ij));
+    else h_Bmass_lep12_areNotPFLep[ij] = (TH1F*)inF->Get(Form("Bmass_l1l2_Track_%d", ij))->Clone(Form("h_Bmass_lep12_areNotPFLep_%d", ij));
     //    h_Bmass[ij]->GetXaxis()->SetRangeUser(4.5, 6.);
   }//loop
 
@@ -118,7 +126,8 @@ void fitBmass_fromHistos(int isEleFinalState, std::string inFile){
     
     RooDataHist hBMass("hBMass", "hBMass", *w.var("x"), Import(*(h_Bmass[ij])));
     RooDataHist hBMass_llt("hBMass_llt", "hBMass_llt", *w.var("x"), Import(*(h_Bmass_llt[ij])));
-    RooDataHist hBMass_not_llt("hBMass_not_llt", "hBMass_not_llt", *w.var("x"), Import(*(h_Bmass_not_llt[ij])));
+    RooDataHist hBMass_lep2_isNotPFLep("hBMass_lep2_isNotPFLep", "hBMass_lep2_isNotPFLep", *w.var("x"), Import(*(h_Bmass_lep2_isNotPFLep[ij])));
+    RooDataHist hBMass_lep12_areNotPFLep("hBMass_lep12_areNotPFLep", "hBMass_lep12_areNotPFLep", *w.var("x"), Import(*(h_Bmass_lep12_areNotPFLep[ij])));
     w.Print();
 
     RooFitResult * r = model->fitTo(hBMass, Minimizer("Minuit2"),Save(true));
@@ -138,9 +147,10 @@ void fitBmass_fromHistos(int isEleFinalState, std::string inFile){
     hBMass.plotOn(plot);
     model->plotOn(plot);
     model->plotOn(plot, Components("modelb"),LineStyle(kDashed));
-    model->plotOn(plot, Components("smodel"),LineColor(kRed));
-    hBMass_llt.plotOn(plot,LineColor(kGreen+2),MarkerColor(kGreen+2)) ;
-    hBMass_not_llt.plotOn(plot,LineColor(kViolet),MarkerColor(kViolet)) ;
+    model->plotOn(plot, Components("smodel"),LineColor(kOrange));
+    hBMass_llt.plotOn(plot,LineColor(kGreen+1),MarkerColor(kGreen+1)) ;
+    hBMass_lep2_isNotPFLep.plotOn(plot,LineColor(kCyan+1),MarkerColor(kCyan+1)) ;
+    hBMass_lep12_areNotPFLep.plotOn(plot,LineColor(kRed),MarkerColor(kRed)) ;
     chi2[ij] = plot->chiSquare();
 
     RooRealVar* parS = (RooRealVar*) r->floatParsFinal().find("nsignal");
@@ -214,4 +224,4 @@ void fitBmass_fromHistos(int isEleFinalState, std::string inFile){
 	      << " chi2 = " << chi2[ij] << std::endl;
   }
 
-} 
+}  


### PR DESCRIPTION
Keep first priority for triplets with both leptons being PF Lep.
Second priority is now given to triplets with one lepton being PFLep and the other lowPtEle (or track).
Finally, triplets with both leptons being lowPtEle (or track) are considered.