### PR TITLE
Selection priorities and new plots

### DIFF
--- a/NtupleProducer/macro/analyzeCharged_fastDATA_Kstll.cpp
+++ b/NtupleProducer/macro/analyzeCharged_fastDATA_Kstll.cpp
@@ -775,7 +775,7 @@ int main(int argc, char **argv){
 
     //choose the best vtxCL candidate provided it survives the selections
     //priority is given to the llt triplets in case of LTT
-    for(int iL=0; iL<2; ++iL){
+    for(int iL=0; iL<3; ++iL){
       if(goodTripletFound) break;
 
       for(unsigned int iP = 0; iP < BToKstll_order_index->size(); ++iP){	
@@ -784,7 +784,9 @@ int main(int argc, char **argv){
 	muon_tag_index_event = Muon_tag_index->at(triplet_sel_index);
 	
 	if( iL == 0 && (BToKstll_lep1_isPFLep[triplet_sel_index] != 1 || BToKstll_lep2_isPFLep[triplet_sel_index] != 1) ) continue;
-	else if( iL == 1 && (BToKstll_lep1_isPFLep[triplet_sel_index] == 1 && BToKstll_lep2_isPFLep[triplet_sel_index] == 1) ) continue;
+	else if( iL == 1 && ( (BToKstll_lep1_isPFLep[triplet_sel_index] == 1 && BToKstll_lep2_isPFLep[triplet_sel_index] == 1) 
+                         || (BToKstll_lep1_isPFLep[triplet_sel_index] != 1 && BToKstll_lep2_isPFLep[triplet_sel_index] != 1) ) ) continue;
+    else if( iL == 2 && (BToKstll_lep1_isPFLep[triplet_sel_index] == 1 || BToKstll_lep2_isPFLep[triplet_sel_index] == 1) ) continue;
 	
 	if(muon_tag_index_event == -1 || triplet_sel_index == -1) continue;
 	if(dataset == "MC" && Muon_probe_index == -1) continue;
@@ -801,7 +803,7 @@ int main(int argc, char **argv){
 	  if(BToKstll_B_Lxy[triplet_sel_index] < 6.) continue;
 	}
 
-	isllt = (iL == 1) ? false : true;
+	isllt = (iL == 0) ? true : false;
 
 	isl1l2_lowPt = bool(BToKstll_lep1_isLowPt[triplet_sel_index] == 1 && BToKstll_lep2_isLowPt[triplet_sel_index]== 1);
     isl1_lowPt = bool(BToKstll_lep1_isLowPt[triplet_sel_index]== 1);

--- a/NtupleProducer/macro/analyzeCharged_fastDATA_Kstll.cpp
+++ b/NtupleProducer/macro/analyzeCharged_fastDATA_Kstll.cpp
@@ -521,8 +521,8 @@ int main(int argc, char **argv){
   TH1F* hKaonpt[7];
   TH1F* hLep1pt[7];
   TH1F* hLep2pt[7];
-  TH1F* hLep1pt_l1notPF[7];
-  TH1F* hLep2pt_l2notPF[7];
+  TH1F* hLep1pt_l1notPFLep[7];
+  TH1F* hLep2pt_l2notPFLep[7];
   TH1F* hLep1pt_PFCand[7];
   TH1F* hLep2pt_PFCand[7];
   TH1F* hLep1pt_LT[7];
@@ -537,9 +537,9 @@ int main(int argc, char **argv){
   TH1F* hBmass[7];
   TH1F* hBmass_llt[7];
   TH1F* hBmass_not_llt[7];
-  TH1F* hBmass_l1PF_l2notPF[7];
-  TH1F* hBmass_l1notPF_l2PF[7];
-  TH1F* hBmass_l1notPF_l2notPF[7];
+  TH1F* hBmass_l1PFLep_l2notPFLep[7];
+  TH1F* hBmass_l1notPFLep_l2PFLep[7];
+  TH1F* hBmass_l1notPFLep_l2notPFLep[7];
   TH1F* hBmass_l1l2_PFCand[7];
   TH1F* hBmass_l2_PFCand[7];
   TH1F* hBmass_l1l2_LT[7];
@@ -595,20 +595,20 @@ int main(int argc, char **argv){
     hBmass_not_llt[ij]->SetLineColor(kRed);
     hBmass_not_llt[ij]->SetLineWidth(2);
     
-    hBmass_l1PF_l2notPF[ij] = new TH1F(Form("Bmass_l1PF_l2notPF_%d", ij), "", 750, 0., 15.); // 75, 4.5, 6.);
-    hBmass_l1PF_l2notPF[ij]->Sumw2();
-    hBmass_l1PF_l2notPF[ij]->SetLineColor(kRed);
-    hBmass_l1PF_l2notPF[ij]->SetLineWidth(2);
+    hBmass_l1PFLep_l2notPFLep[ij] = new TH1F(Form("Bmass_l1PFLep_l2notPFLep_%d", ij), "", 750, 0., 15.); // 75, 4.5, 6.);
+    hBmass_l1PFLep_l2notPFLep[ij]->Sumw2();
+    hBmass_l1PFLep_l2notPFLep[ij]->SetLineColor(kRed);
+    hBmass_l1PFLep_l2notPFLep[ij]->SetLineWidth(2);
     
-    hBmass_l1notPF_l2PF[ij] = new TH1F(Form("Bmass_l1notPF_l2PF_%d", ij), "", 750, 0., 15.); // 75, 4.5, 6.);
-    hBmass_l1notPF_l2PF[ij]->Sumw2();
-    hBmass_l1notPF_l2PF[ij]->SetLineColor(kRed);
-    hBmass_l1notPF_l2PF[ij]->SetLineWidth(2);
+    hBmass_l1notPFLep_l2PFLep[ij] = new TH1F(Form("Bmass_l1notPFLep_l2PFLep_%d", ij), "", 750, 0., 15.); // 75, 4.5, 6.);
+    hBmass_l1notPFLep_l2PFLep[ij]->Sumw2();
+    hBmass_l1notPFLep_l2PFLep[ij]->SetLineColor(kRed);
+    hBmass_l1notPFLep_l2PFLep[ij]->SetLineWidth(2);
     
-    hBmass_l1notPF_l2notPF[ij] = new TH1F(Form("Bmass_l1notPF_l2notPF_%d", ij), "", 750, 0., 15.); // 75, 4.5, 6.);
-    hBmass_l1notPF_l2notPF[ij]->Sumw2();
-    hBmass_l1notPF_l2notPF[ij]->SetLineColor(kRed);
-    hBmass_l1notPF_l2notPF[ij]->SetLineWidth(2);   
+    hBmass_l1notPFLep_l2notPFLep[ij] = new TH1F(Form("Bmass_l1notPFLep_l2notPFLep_%d", ij), "", 750, 0., 15.); // 75, 4.5, 6.);
+    hBmass_l1notPFLep_l2notPFLep[ij]->Sumw2();
+    hBmass_l1notPFLep_l2notPFLep[ij]->SetLineColor(kRed);
+    hBmass_l1notPFLep_l2notPFLep[ij]->SetLineWidth(2);   
     
     hBmass_l1l2_PFCand[ij] = new TH1F(Form("Bmass_l1l2_PFCand_%d", ij), "", 750, 0., 15.); // 75, 4.5, 6.);
     hBmass_l1l2_PFCand[ij]->Sumw2();
@@ -645,10 +645,10 @@ int main(int argc, char **argv){
     hLep1pt[ij]->SetLineColor(kRed);
     hLep1pt[ij]->SetLineWidth(2);
 
-    hLep1pt_l1notPF[ij] = new TH1F(Form("hLep1pt_l1notPF_%d", ij), "", 100, 0., 10.);
-    hLep1pt_l1notPF[ij]->Sumw2();
-    hLep1pt_l1notPF[ij]->SetLineColor(kRed);
-    hLep1pt_l1notPF[ij]->SetLineWidth(2);
+    hLep1pt_l1notPFLep[ij] = new TH1F(Form("hLep1pt_l1notPFLep_%d", ij), "", 100, 0., 10.);
+    hLep1pt_l1notPFLep[ij]->Sumw2();
+    hLep1pt_l1notPFLep[ij]->SetLineColor(kRed);
+    hLep1pt_l1notPFLep[ij]->SetLineWidth(2);
     
     hLep1pt_PFCand[ij] = new TH1F(Form("hLep1pt_PFCand_%d", ij), "", 100, 0., 10.);
     hLep1pt_PFCand[ij]->Sumw2();
@@ -665,10 +665,10 @@ int main(int argc, char **argv){
     hLep2pt[ij]->SetLineColor(kRed);
     hLep2pt[ij]->SetLineWidth(2);
     
-    hLep2pt_l2notPF[ij] = new TH1F(Form("hLep2pt_l2notPF_%d", ij), "", 100, 0., 10.);
-    hLep2pt_l2notPF[ij]->Sumw2();
-    hLep2pt_l2notPF[ij]->SetLineColor(kRed);
-    hLep2pt_l2notPF[ij]->SetLineWidth(2);    
+    hLep2pt_l2notPFLep[ij] = new TH1F(Form("hLep2pt_l2notPFLep_%d", ij), "", 100, 0., 10.);
+    hLep2pt_l2notPFLep[ij]->Sumw2();
+    hLep2pt_l2notPFLep[ij]->SetLineColor(kRed);
+    hLep2pt_l2notPFLep[ij]->SetLineWidth(2);    
     
     hLep2pt_PFCand[ij] = new TH1F(Form("hLep2pt_PFCand_%d", ij), "", 100, 0., 10.);
     hLep2pt_PFCand[ij]->Sumw2();
@@ -750,9 +750,9 @@ int main(int argc, char **argv){
     bool isl1l2_LT = false;
     bool isl1_LT = false;
     bool isl2_LT = false;
-    bool l1PF_l2notPF = false;
-    bool l1notPF_l2PF = false;
-    bool l1notPF_l2notPF = false;
+    bool l1PFLep_l2notPFLep = false;
+    bool l1notPFLep_l2PFLep = false;
+    bool l1notPFLep_l2notPFLep = false;
     bool goodTripletFound = false;
 
     //choose the best vtxCL candidate provided it survives the selections
@@ -795,9 +795,9 @@ int main(int argc, char **argv){
     isl1_LT = bool(BToKstll_lep1_isLT[triplet_sel_index]== 1);
     isl2_LT = bool(BToKstll_lep2_isLT[triplet_sel_index]== 1);
     
-    l1PF_l2notPF = bool(BToKstll_lep1_isPFCand[triplet_sel_index] == 1 && BToKstll_lep2_isPFCand[triplet_sel_index] != 1);
-    l1notPF_l2PF = bool(BToKstll_lep1_isPFCand[triplet_sel_index] != 1 && BToKstll_lep2_isPFCand[triplet_sel_index] == 1);
-    l1notPF_l2notPF = bool(BToKstll_lep1_isPFCand[triplet_sel_index] != 1 && BToKstll_lep2_isPFCand[triplet_sel_index] != 1);    
+    l1PFLep_l2notPFLep = bool(BToKstll_lep1_isPFCand[triplet_sel_index] == 1 && BToKstll_lep2_isPFCand[triplet_sel_index] != 1);
+    l1notPFLep_l2PFLep = bool(BToKstll_lep1_isPFCand[triplet_sel_index] != 1 && BToKstll_lep2_isPFCand[triplet_sel_index] == 1);
+    l1notPFLep_l2notPFLep = bool(BToKstll_lep1_isPFCand[triplet_sel_index] != 1 && BToKstll_lep2_isPFCand[triplet_sel_index] != 1);    
     
 	goodTripletFound = true;
 	break;
@@ -917,8 +917,8 @@ int main(int argc, char **argv){
 
       hLep1pt[massBin]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
       hLep2pt[massBin]->Fill(BToKstll_lep2_pt[triplet_sel_index]);
-      if(l1notPF_l2PF || l1notPF_l2notPF)hLep1pt_l1notPF[massBin]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
-      if(l1PF_l2notPF || l1notPF_l2notPF)hLep2pt_l2notPF[massBin]->Fill(BToKstll_lep2_pt[triplet_sel_index]);
+      if(l1notPFLep_l2PFLep || l1notPFLep_l2notPFLep)hLep1pt_l1notPFLep[massBin]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
+      if(l1PFLep_l2notPFLep || l1notPFLep_l2notPFLep)hLep2pt_l2notPFLep[massBin]->Fill(BToKstll_lep2_pt[triplet_sel_index]);
       if(std::abs(BToKstll_lep1_eta[triplet_sel_index]) < 1.47) hLep1pt_EB[massBin]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
       else hLep1pt_EE[massBin]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
       if(std::abs(BToKstll_lep2_eta[triplet_sel_index]) < 1.47) hLep2pt_EB[massBin]->Fill(BToKstll_lep2_pt[triplet_sel_index]);
@@ -929,9 +929,9 @@ int main(int argc, char **argv){
       hBmass[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
       if(isllt) hBmass_llt[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
       else hBmass_not_llt[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
-      if(l1PF_l2notPF) hBmass_l1PF_l2notPF[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
-      if(l1notPF_l2PF) hBmass_l1notPF_l2PF[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
-      if(l1notPF_l2notPF) hBmass_l1notPF_l2notPF[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
+      if(l1PFLep_l2notPFLep) hBmass_l1PFLep_l2notPFLep[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
+      if(l1notPFLep_l2PFLep) hBmass_l1notPFLep_l2PFLep[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
+      if(l1notPFLep_l2notPFLep) hBmass_l1notPFLep_l2notPFLep[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
       if(isl1l2_PFCand) hBmass_l1l2_PFCand[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
       if(isl1_PFCand) hLep1pt_PFCand[massBin]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
       if(isl2_PFCand){ 
@@ -957,9 +957,9 @@ int main(int argc, char **argv){
     hBmass[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
     if(isllt) hBmass_llt[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
     else hBmass_not_llt[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
-    if(l1PF_l2notPF) hBmass_l1PF_l2notPF[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
-    if(l1notPF_l2PF) hBmass_l1notPF_l2PF[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
-    if(l1notPF_l2notPF) hBmass_l1notPF_l2notPF[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
+    if(l1PFLep_l2notPFLep) hBmass_l1PFLep_l2notPFLep[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
+    if(l1notPFLep_l2PFLep) hBmass_l1notPFLep_l2PFLep[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
+    if(l1notPFLep_l2notPFLep) hBmass_l1notPFLep_l2notPFLep[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
     if(isl1l2_PFCand) hBmass_l1l2_PFCand[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
     if(isl1_PFCand) hLep1pt_PFCand[6]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
     if(isl2_PFCand){
@@ -983,8 +983,8 @@ int main(int argc, char **argv){
 
     hLep1pt[6]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
     hLep2pt[6]->Fill(BToKstll_lep2_pt[triplet_sel_index]);
-    if(l1notPF_l2PF || l1notPF_l2notPF)hLep1pt_l1notPF[6]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
-    if(l1PF_l2notPF || l1notPF_l2notPF)hLep2pt_l2notPF[6]->Fill(BToKstll_lep2_pt[triplet_sel_index]);
+    if(l1notPFLep_l2PFLep || l1notPFLep_l2notPFLep)hLep1pt_l1notPFLep[6]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
+    if(l1PFLep_l2notPFLep || l1notPFLep_l2notPFLep)hLep2pt_l2notPFLep[6]->Fill(BToKstll_lep2_pt[triplet_sel_index]);
     if(std::abs(BToKstll_lep1_eta[triplet_sel_index]) < 1.47) hLep1pt_EB[6]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
     else hLep1pt_EE[6]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
     if(std::abs(BToKstll_lep2_eta[triplet_sel_index]) < 1.47) hLep2pt_EB[6]->Fill(BToKstll_lep2_pt[triplet_sel_index]);
@@ -1019,11 +1019,11 @@ int main(int argc, char **argv){
     hctxy[ij]->Write(hctxy[ij]->GetName());
     hKaonpt[ij]->Write(hKaonpt[ij]->GetName());
     hLep1pt[ij]->Write(hLep1pt[ij]->GetName());
-    hLep1pt_l1notPF[ij]->Write(hLep1pt_l1notPF[ij]->GetName());
+    hLep1pt_l1notPFLep[ij]->Write(hLep1pt_l1notPFLep[ij]->GetName());
     hLep1pt_PFCand[ij]->Write(hLep1pt_PFCand[ij]->GetName());
     hLep1pt_LT[ij]->Write(hLep1pt_LT[ij]->GetName());
     hLep2pt[ij]->Write(hLep2pt[ij]->GetName());
-    hLep2pt_l2notPF[ij]->Write(hLep2pt_l2notPF[ij]->GetName());
+    hLep2pt_l2notPFLep[ij]->Write(hLep2pt_l2notPFLep[ij]->GetName());
     hLep2pt_PFCand[ij]->Write(hLep2pt_PFCand[ij]->GetName());
     hLep2pt_LT[ij]->Write(hLep2pt_LT[ij]->GetName());
     hLep1pt_EB[ij]->Write(hLep1pt_EB[ij]->GetName());
@@ -1039,9 +1039,9 @@ int main(int argc, char **argv){
     hBmass[ij]->Write(hBmass[ij]->GetName());
     hBmass_llt[ij]->Write(hBmass_llt[ij]->GetName());
     hBmass_not_llt[ij]->Write(hBmass_not_llt[ij]->GetName());
-    hBmass_l1notPF_l2PF[ij]->Write(hBmass_l1notPF_l2PF[ij]->GetName());
-    hBmass_l1PF_l2notPF[ij]->Write(hBmass_l1PF_l2notPF[ij]->GetName());
-    hBmass_l1notPF_l2notPF[ij]->Write(hBmass_l1notPF_l2notPF[ij]->GetName());
+    hBmass_l1notPFLep_l2PFLep[ij]->Write(hBmass_l1notPFLep_l2PFLep[ij]->GetName());
+    hBmass_l1PFLep_l2notPFLep[ij]->Write(hBmass_l1PFLep_l2notPFLep[ij]->GetName());
+    hBmass_l1notPFLep_l2notPFLep[ij]->Write(hBmass_l1notPFLep_l2notPFLep[ij]->GetName());
     hBmass_l1l2_PFCand[ij]->Write(hBmass_l1l2_PFCand[ij]->GetName());
     hBmass_l2_PFCand[ij]->Write(hBmass_l2_PFCand[ij]->GetName());
     hBmass_l1l2_LT[ij]->Write(hBmass_l1l2_LT[ij]->GetName());

--- a/NtupleProducer/macro/analyzeCharged_fastDATA_Kstll.cpp
+++ b/NtupleProducer/macro/analyzeCharged_fastDATA_Kstll.cpp
@@ -521,14 +521,12 @@ int main(int argc, char **argv){
   TH1F* hKaonpt[7];
   TH1F* hLep1pt[7];
   TH1F* hLep2pt[7];
-  TH1F* hLep1pt_lowPt[7];
-  TH1F* hLep2pt_lowPt[7];
+  TH1F* hLep1pt_l1notPF[7];
+  TH1F* hLep2pt_l2notPF[7];
   TH1F* hLep1pt_PFCand[7];
   TH1F* hLep2pt_PFCand[7];
   TH1F* hLep1pt_LT[7];
-  TH1F* hLep2pt_LT[7];
-  TH1F* hLep1pt_Track[7];
-  TH1F* hLep2pt_Track[7];  
+  TH1F* hLep2pt_LT[7];  
   TH1F* hLep1pt_EB[7];
   TH1F* hLep2pt_EB[7];
   TH1F* hLep1pt_EE[7];
@@ -539,14 +537,13 @@ int main(int argc, char **argv){
   TH1F* hBmass[7];
   TH1F* hBmass_llt[7];
   TH1F* hBmass_not_llt[7];
-  TH1F* hBmass_l1l2_lowPt[7];
-  TH1F* hBmass_l2_lowPt[7];
+  TH1F* hBmass_l1PF_l2notPF[7];
+  TH1F* hBmass_l1notPF_l2PF[7];
+  TH1F* hBmass_l1notPF_l2notPF[7];
   TH1F* hBmass_l1l2_PFCand[7];
   TH1F* hBmass_l2_PFCand[7];
   TH1F* hBmass_l1l2_LT[7];
   TH1F* hBmass_l2_LT[7];
-  TH1F* hBmass_l1l2_Track[7];
-  TH1F* hBmass_l2_Track[7];
   TH2F* BDTele1_vs_pTele1[7];
   TH2F* BDTele2_vs_pTele2[7];
   TH2F* BDTele2_vs_BDTele1[7];
@@ -597,16 +594,21 @@ int main(int argc, char **argv){
     hBmass_not_llt[ij]->Sumw2();
     hBmass_not_llt[ij]->SetLineColor(kRed);
     hBmass_not_llt[ij]->SetLineWidth(2);
-
-    hBmass_l1l2_lowPt[ij] = new TH1F(Form("Bmass_l1l2_lowPt_%d", ij), "", 750, 0., 15.); // 75, 4.5, 6.);
-    hBmass_l1l2_lowPt[ij]->Sumw2();
-    hBmass_l1l2_lowPt[ij]->SetLineColor(kRed);
-    hBmass_l1l2_lowPt[ij]->SetLineWidth(2);
-
-    hBmass_l2_lowPt[ij] = new TH1F(Form("Bmass_l2_lowPt_%d", ij), "", 750, 0., 15.); // 75, 4.5, 6.);
-    hBmass_l2_lowPt[ij]->Sumw2();
-    hBmass_l2_lowPt[ij]->SetLineColor(kRed);
-    hBmass_l2_lowPt[ij]->SetLineWidth(2);
+    
+    hBmass_l1PF_l2notPF[ij] = new TH1F(Form("Bmass_l1PF_l2notPF_%d", ij), "", 750, 0., 15.); // 75, 4.5, 6.);
+    hBmass_l1PF_l2notPF[ij]->Sumw2();
+    hBmass_l1PF_l2notPF[ij]->SetLineColor(kRed);
+    hBmass_l1PF_l2notPF[ij]->SetLineWidth(2);
+    
+    hBmass_l1notPF_l2PF[ij] = new TH1F(Form("Bmass_l1notPF_l2PF_%d", ij), "", 750, 0., 15.); // 75, 4.5, 6.);
+    hBmass_l1notPF_l2PF[ij]->Sumw2();
+    hBmass_l1notPF_l2PF[ij]->SetLineColor(kRed);
+    hBmass_l1notPF_l2PF[ij]->SetLineWidth(2);
+    
+    hBmass_l1notPF_l2notPF[ij] = new TH1F(Form("Bmass_l1notPF_l2notPF_%d", ij), "", 750, 0., 15.); // 75, 4.5, 6.);
+    hBmass_l1notPF_l2notPF[ij]->Sumw2();
+    hBmass_l1notPF_l2notPF[ij]->SetLineColor(kRed);
+    hBmass_l1notPF_l2notPF[ij]->SetLineWidth(2);   
     
     hBmass_l1l2_PFCand[ij] = new TH1F(Form("Bmass_l1l2_PFCand_%d", ij), "", 750, 0., 15.); // 75, 4.5, 6.);
     hBmass_l1l2_PFCand[ij]->Sumw2();
@@ -626,17 +628,7 @@ int main(int argc, char **argv){
     hBmass_l2_LT[ij] = new TH1F(Form("Bmass_l2_LT_%d", ij), "", 750, 0., 15.); // 75, 4.5, 6.);
     hBmass_l2_LT[ij]->Sumw2();
     hBmass_l2_LT[ij]->SetLineColor(kRed);
-    hBmass_l2_LT[ij]->SetLineWidth(2);
-
-    hBmass_l1l2_Track[ij] = new TH1F(Form("Bmass_l1l2_Track_%d", ij), "", 750, 0., 15.); // 75, 4.5, 6.);
-    hBmass_l1l2_Track[ij]->Sumw2();
-    hBmass_l1l2_Track[ij]->SetLineColor(kRed);
-    hBmass_l1l2_Track[ij]->SetLineWidth(2);
-    
-    hBmass_l2_Track[ij] = new TH1F(Form("Bmass_l2_Track_%d", ij), "", 750, 0., 15.); // 75, 4.5, 6.);
-    hBmass_l2_Track[ij]->Sumw2();
-    hBmass_l2_Track[ij]->SetLineColor(kRed);
-    hBmass_l2_Track[ij]->SetLineWidth(2);    
+    hBmass_l2_LT[ij]->SetLineWidth(2);   
 
     hctxy[ij] = new TH1F(Form("hctxy_%d", ij), "", 1000, 0., 10.);
     hctxy[ij]->Sumw2();
@@ -653,10 +645,10 @@ int main(int argc, char **argv){
     hLep1pt[ij]->SetLineColor(kRed);
     hLep1pt[ij]->SetLineWidth(2);
 
-    hLep1pt_lowPt[ij] = new TH1F(Form("hLep1pt_lowPt_%d", ij), "", 100, 0., 10.);
-    hLep1pt_lowPt[ij]->Sumw2();
-    hLep1pt_lowPt[ij]->SetLineColor(kRed);
-    hLep1pt_lowPt[ij]->SetLineWidth(2);
+    hLep1pt_l1notPF[ij] = new TH1F(Form("hLep1pt_l1notPF_%d", ij), "", 100, 0., 10.);
+    hLep1pt_l1notPF[ij]->Sumw2();
+    hLep1pt_l1notPF[ij]->SetLineColor(kRed);
+    hLep1pt_l1notPF[ij]->SetLineWidth(2);
     
     hLep1pt_PFCand[ij] = new TH1F(Form("hLep1pt_PFCand_%d", ij), "", 100, 0., 10.);
     hLep1pt_PFCand[ij]->Sumw2();
@@ -666,22 +658,17 @@ int main(int argc, char **argv){
     hLep1pt_LT[ij] = new TH1F(Form("hLep1pt_LT_%d", ij), "", 100, 0., 10.);
     hLep1pt_LT[ij]->Sumw2();
     hLep1pt_LT[ij]->SetLineColor(kRed);
-    hLep1pt_LT[ij]->SetLineWidth(2);
-
-    hLep1pt_Track[ij] = new TH1F(Form("hLep1pt_Track_%d", ij), "", 100, 0., 10.);
-    hLep1pt_Track[ij]->Sumw2();
-    hLep1pt_Track[ij]->SetLineColor(kRed);
-    hLep1pt_Track[ij]->SetLineWidth(2);    
+    hLep1pt_LT[ij]->SetLineWidth(2);    
 
     hLep2pt[ij] = new TH1F(Form("hLep2pt_%d", ij), "", 100, 0., 10.);
     hLep2pt[ij]->Sumw2();
     hLep2pt[ij]->SetLineColor(kRed);
     hLep2pt[ij]->SetLineWidth(2);
     
-    hLep2pt_lowPt[ij] = new TH1F(Form("hLep2pt_lowPt_%d", ij), "", 100, 0., 10.);
-    hLep2pt_lowPt[ij]->Sumw2();
-    hLep2pt_lowPt[ij]->SetLineColor(kRed);
-    hLep2pt_lowPt[ij]->SetLineWidth(2);    
+    hLep2pt_l2notPF[ij] = new TH1F(Form("hLep2pt_l2notPF_%d", ij), "", 100, 0., 10.);
+    hLep2pt_l2notPF[ij]->Sumw2();
+    hLep2pt_l2notPF[ij]->SetLineColor(kRed);
+    hLep2pt_l2notPF[ij]->SetLineWidth(2);    
     
     hLep2pt_PFCand[ij] = new TH1F(Form("hLep2pt_PFCand_%d", ij), "", 100, 0., 10.);
     hLep2pt_PFCand[ij]->Sumw2();
@@ -692,11 +679,6 @@ int main(int argc, char **argv){
     hLep2pt_LT[ij]->Sumw2();
     hLep2pt_LT[ij]->SetLineColor(kRed);
     hLep2pt_LT[ij]->SetLineWidth(2);
-
-    hLep2pt_Track[ij] = new TH1F(Form("hLep2pt_Track_%d", ij), "", 100, 0., 10.);
-    hLep2pt_Track[ij]->Sumw2();
-    hLep2pt_Track[ij]->SetLineColor(kRed);
-    hLep2pt_Track[ij]->SetLineWidth(2);    
 
     //
     hLep1pt_EB[ij] = new TH1F(Form("hLep1pt_EB_%d", ij), "", 100, 0., 10.);
@@ -762,15 +744,15 @@ int main(int argc, char **argv){
     int muon_tag_index_event = -1;
     int triplet_sel_index = -1;
     bool isllt = false;         
-    bool isl1l2_lowPt = false;
-    bool isl1_lowPt = false;
-    bool isl2_lowPt = false;
     bool isl1l2_PFCand = false;
     bool isl1_PFCand = false;
     bool isl2_PFCand = false;
     bool isl1l2_LT = false;
     bool isl1_LT = false;
     bool isl2_LT = false;
+    bool l1PF_l2notPF = false;
+    bool l1notPF_l2PF = false;
+    bool l1notPF_l2notPF = false;
     bool goodTripletFound = false;
 
     //choose the best vtxCL candidate provided it survives the selections
@@ -805,10 +787,6 @@ int main(int argc, char **argv){
 
 	isllt = (iL == 0) ? true : false;
 
-	isl1l2_lowPt = bool(BToKstll_lep1_isLowPt[triplet_sel_index] == 1 && BToKstll_lep2_isLowPt[triplet_sel_index]== 1);
-    isl1_lowPt = bool(BToKstll_lep1_isLowPt[triplet_sel_index]== 1);
-    isl2_lowPt = bool(BToKstll_lep2_isLowPt[triplet_sel_index]== 1);
-
     isl1l2_PFCand = bool(BToKstll_lep1_isPFCand[triplet_sel_index] == 1 && BToKstll_lep2_isPFCand[triplet_sel_index]== 1);
     isl1_PFCand = bool(BToKstll_lep1_isPFCand[triplet_sel_index]== 1);
     isl2_PFCand = bool(BToKstll_lep2_isPFCand[triplet_sel_index]== 1);
@@ -816,6 +794,10 @@ int main(int argc, char **argv){
     isl1l2_LT = bool(BToKstll_lep1_isLT[triplet_sel_index] == 1 && BToKstll_lep2_isLT[triplet_sel_index]== 1);
     isl1_LT = bool(BToKstll_lep1_isLT[triplet_sel_index]== 1);
     isl2_LT = bool(BToKstll_lep2_isLT[triplet_sel_index]== 1);
+    
+    l1PF_l2notPF = bool(BToKstll_lep1_isPFCand[triplet_sel_index] == 1 && BToKstll_lep2_isPFCand[triplet_sel_index] != 1);
+    l1notPF_l2PF = bool(BToKstll_lep1_isPFCand[triplet_sel_index] != 1 && BToKstll_lep2_isPFCand[triplet_sel_index] == 1);
+    l1notPF_l2notPF = bool(BToKstll_lep1_isPFCand[triplet_sel_index] != 1 && BToKstll_lep2_isPFCand[triplet_sel_index] != 1);    
     
 	goodTripletFound = true;
 	break;
@@ -935,6 +917,8 @@ int main(int argc, char **argv){
 
       hLep1pt[massBin]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
       hLep2pt[massBin]->Fill(BToKstll_lep2_pt[triplet_sel_index]);
+      if(l1notPF_l2PF || l1notPF_l2notPF)hLep1pt_l1notPF[massBin]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
+      if(l1PF_l2notPF || l1notPF_l2notPF)hLep2pt_l2notPF[massBin]->Fill(BToKstll_lep2_pt[triplet_sel_index]);
       if(std::abs(BToKstll_lep1_eta[triplet_sel_index]) < 1.47) hLep1pt_EB[massBin]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
       else hLep1pt_EE[massBin]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
       if(std::abs(BToKstll_lep2_eta[triplet_sel_index]) < 1.47) hLep2pt_EB[massBin]->Fill(BToKstll_lep2_pt[triplet_sel_index]);
@@ -945,12 +929,9 @@ int main(int argc, char **argv){
       hBmass[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
       if(isllt) hBmass_llt[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
       else hBmass_not_llt[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
-      if(isl1l2_lowPt) hBmass_l1l2_lowPt[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
-      if(isl1_lowPt) hLep1pt_lowPt[massBin]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
-      if(isl2_lowPt){
-        hBmass_l2_lowPt[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
-        hLep2pt_lowPt[massBin]->Fill(BToKstll_lep2_pt[triplet_sel_index]);
-      }
+      if(l1PF_l2notPF) hBmass_l1PF_l2notPF[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
+      if(l1notPF_l2PF) hBmass_l1notPF_l2PF[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
+      if(l1notPF_l2notPF) hBmass_l1notPF_l2notPF[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
       if(isl1l2_PFCand) hBmass_l1l2_PFCand[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
       if(isl1_PFCand) hLep1pt_PFCand[massBin]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
       if(isl2_PFCand){ 
@@ -962,12 +943,6 @@ int main(int argc, char **argv){
       if(isl2_LT){
         hBmass_l2_LT[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
         hLep2pt_LT[massBin]->Fill(BToKstll_lep2_pt[triplet_sel_index]);
-      }
-      if(isl1l2_PFCand || isl1l2_LT) hBmass_l1l2_Track[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
-      if(isl1_PFCand || isl1_LT) hLep1pt_Track[massBin]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
-      if(isl2_PFCand || isl2_LT){
-        hBmass_l2_Track[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
-        hLep2pt_Track[massBin]->Fill(BToKstll_lep2_pt[triplet_sel_index]);
       }
 
       BDTele1_vs_pTele1[massBin]->Fill(BToKstll_lep1_pt[triplet_sel_index], BToKstll_lep1_seedBDT_unbiased[triplet_sel_index]);
@@ -982,12 +957,9 @@ int main(int argc, char **argv){
     hBmass[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
     if(isllt) hBmass_llt[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
     else hBmass_not_llt[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
-    if(isl1l2_lowPt) hBmass_l1l2_lowPt[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
-    if(isl1_lowPt) hLep1pt_lowPt[6]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
-    if(isl2_lowPt){
-        hBmass_l2_lowPt[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
-        hLep2pt_lowPt[6]->Fill(BToKstll_lep2_pt[triplet_sel_index]);
-    }
+    if(l1PF_l2notPF) hBmass_l1PF_l2notPF[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
+    if(l1notPF_l2PF) hBmass_l1notPF_l2PF[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
+    if(l1notPF_l2notPF) hBmass_l1notPF_l2notPF[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
     if(isl1l2_PFCand) hBmass_l1l2_PFCand[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
     if(isl1_PFCand) hLep1pt_PFCand[6]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
     if(isl2_PFCand){
@@ -1000,12 +972,7 @@ int main(int argc, char **argv){
         hBmass_l2_LT[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
         hLep2pt_LT[6]->Fill(BToKstll_lep2_pt[triplet_sel_index]);
     }
-    if(isl1l2_PFCand || isl1l2_LT) hBmass_l1l2_Track[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
-    if(isl1_PFCand || isl1_LT) hLep1pt_Track[6]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
-    if(isl2_PFCand || isl2_LT){
-        hBmass_l2_Track[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
-        hLep2pt_Track[6]->Fill(BToKstll_lep2_pt[triplet_sel_index]);
-    }
+
     hAlpha[6]->Fill(BToKstll_B_cosAlpha[triplet_sel_index]);
     hCLVtx[6]->Fill(BToKstll_B_CL_vtx[triplet_sel_index]);
     hDCASig[6]->Fill(BToKstll_kaon_DCASig[triplet_sel_index]);
@@ -1016,6 +983,8 @@ int main(int argc, char **argv){
 
     hLep1pt[6]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
     hLep2pt[6]->Fill(BToKstll_lep2_pt[triplet_sel_index]);
+    if(l1notPF_l2PF || l1notPF_l2notPF)hLep1pt_l1notPF[6]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
+    if(l1PF_l2notPF || l1notPF_l2notPF)hLep2pt_l2notPF[6]->Fill(BToKstll_lep2_pt[triplet_sel_index]);
     if(std::abs(BToKstll_lep1_eta[triplet_sel_index]) < 1.47) hLep1pt_EB[6]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
     else hLep1pt_EE[6]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
     if(std::abs(BToKstll_lep2_eta[triplet_sel_index]) < 1.47) hLep2pt_EB[6]->Fill(BToKstll_lep2_pt[triplet_sel_index]);
@@ -1050,15 +1019,13 @@ int main(int argc, char **argv){
     hctxy[ij]->Write(hctxy[ij]->GetName());
     hKaonpt[ij]->Write(hKaonpt[ij]->GetName());
     hLep1pt[ij]->Write(hLep1pt[ij]->GetName());
-    hLep1pt_lowPt[ij]->Write(hLep1pt_lowPt[ij]->GetName());
+    hLep1pt_l1notPF[ij]->Write(hLep1pt_l1notPF[ij]->GetName());
     hLep1pt_PFCand[ij]->Write(hLep1pt_PFCand[ij]->GetName());
     hLep1pt_LT[ij]->Write(hLep1pt_LT[ij]->GetName());
-    hLep1pt_Track[ij]->Write(hLep1pt_Track[ij]->GetName());
     hLep2pt[ij]->Write(hLep2pt[ij]->GetName());
-    hLep2pt_lowPt[ij]->Write(hLep2pt_lowPt[ij]->GetName());
+    hLep2pt_l2notPF[ij]->Write(hLep2pt_l2notPF[ij]->GetName());
     hLep2pt_PFCand[ij]->Write(hLep2pt_PFCand[ij]->GetName());
     hLep2pt_LT[ij]->Write(hLep2pt_LT[ij]->GetName());
-    hLep2pt_Track[ij]->Write(hLep2pt_Track[ij]->GetName());
     hLep1pt_EB[ij]->Write(hLep1pt_EB[ij]->GetName());
     hLep1pt_EE[ij]->Write(hLep1pt_EE[ij]->GetName());
     hLep2pt_EB[ij]->Write(hLep2pt_EB[ij]->GetName());
@@ -1072,14 +1039,13 @@ int main(int argc, char **argv){
     hBmass[ij]->Write(hBmass[ij]->GetName());
     hBmass_llt[ij]->Write(hBmass_llt[ij]->GetName());
     hBmass_not_llt[ij]->Write(hBmass_not_llt[ij]->GetName());
-    hBmass_l1l2_lowPt[ij]->Write(hBmass_l1l2_lowPt[ij]->GetName());
-    hBmass_l2_lowPt[ij]->Write(hBmass_l2_lowPt[ij]->GetName());
+    hBmass_l1notPF_l2PF[ij]->Write(hBmass_l1notPF_l2PF[ij]->GetName());
+    hBmass_l1PF_l2notPF[ij]->Write(hBmass_l1PF_l2notPF[ij]->GetName());
+    hBmass_l1notPF_l2notPF[ij]->Write(hBmass_l1notPF_l2notPF[ij]->GetName());
     hBmass_l1l2_PFCand[ij]->Write(hBmass_l1l2_PFCand[ij]->GetName());
     hBmass_l2_PFCand[ij]->Write(hBmass_l2_PFCand[ij]->GetName());
     hBmass_l1l2_LT[ij]->Write(hBmass_l1l2_LT[ij]->GetName());
     hBmass_l2_LT[ij]->Write(hBmass_l2_LT[ij]->GetName());
-    hBmass_l1l2_Track[ij]->Write(hBmass_l1l2_Track[ij]->GetName());
-    hBmass_l2_Track[ij]->Write(hBmass_l2_Track[ij]->GetName());
 
     BDTele1_vs_pTele1[ij]->Write(BDTele1_vs_pTele1[ij]->GetName());
     BDTele2_vs_pTele2[ij]->Write(BDTele2_vs_pTele2[ij]->GetName());

--- a/NtupleProducer/macro/analyzeCharged_fastDATA_Kstll.cpp
+++ b/NtupleProducer/macro/analyzeCharged_fastDATA_Kstll.cpp
@@ -540,10 +540,12 @@ int main(int argc, char **argv){
   TH1F* hBmass_l1PFLep_l2notPFLep[7];
   TH1F* hBmass_l1notPFLep_l2PFLep[7];
   TH1F* hBmass_l1notPFLep_l2notPFLep[7];
-  TH1F* hBmass_l1l2_PFCand[7];
-  TH1F* hBmass_l2_PFCand[7];
-  TH1F* hBmass_l1l2_LT[7];
-  TH1F* hBmass_l2_LT[7];
+  TH1F* hBmass_l1PFCand_l2PFCand[7];
+  TH1F* hBmass_l1PFCand_l2notPFCand[7];
+  TH1F* hBmass_l1notPFCand_l2PFCand[7];
+  TH1F* hBmass_l1LT_l2LT[7];
+  TH1F* hBmass_l1LT_l2notLT[7];
+  TH1F* hBmass_l1notLT_l2LT[7];
   TH2F* BDTele1_vs_pTele1[7];
   TH2F* BDTele2_vs_pTele2[7];
   TH2F* BDTele2_vs_BDTele1[7];
@@ -610,25 +612,35 @@ int main(int argc, char **argv){
     hBmass_l1notPFLep_l2notPFLep[ij]->SetLineColor(kRed);
     hBmass_l1notPFLep_l2notPFLep[ij]->SetLineWidth(2);   
     
-    hBmass_l1l2_PFCand[ij] = new TH1F(Form("Bmass_l1l2_PFCand_%d", ij), "", 750, 0., 15.); // 75, 4.5, 6.);
-    hBmass_l1l2_PFCand[ij]->Sumw2();
-    hBmass_l1l2_PFCand[ij]->SetLineColor(kRed);
-    hBmass_l1l2_PFCand[ij]->SetLineWidth(2);
+    hBmass_l1PFCand_l2PFCand[ij] = new TH1F(Form("Bmass_l1PFCand_l2PFCand_%d", ij), "", 750, 0., 15.); // 75, 4.5, 6.);
+    hBmass_l1PFCand_l2PFCand[ij]->Sumw2();
+    hBmass_l1PFCand_l2PFCand[ij]->SetLineColor(kRed);
+    hBmass_l1PFCand_l2PFCand[ij]->SetLineWidth(2);
     
-    hBmass_l2_PFCand[ij] = new TH1F(Form("Bmass_l2_PFCand_%d", ij), "", 750, 0., 15.); // 75, 4.5, 6.);
-    hBmass_l2_PFCand[ij]->Sumw2();
-    hBmass_l2_PFCand[ij]->SetLineColor(kRed);
-    hBmass_l2_PFCand[ij]->SetLineWidth(2);
+    hBmass_l1PFCand_l2notPFCand[ij] = new TH1F(Form("Bmass_l1PFCand_l2notPFCand_%d", ij), "", 750, 0., 15.); // 75, 4.5, 6.);
+    hBmass_l1PFCand_l2notPFCand[ij]->Sumw2();
+    hBmass_l1PFCand_l2notPFCand[ij]->SetLineColor(kRed);
+    hBmass_l1PFCand_l2notPFCand[ij]->SetLineWidth(2);
     
-    hBmass_l1l2_LT[ij] = new TH1F(Form("Bmass_l1l2_LT_%d", ij), "", 750, 0., 15.); // 75, 4.5, 6.);
-    hBmass_l1l2_LT[ij]->Sumw2();
-    hBmass_l1l2_LT[ij]->SetLineColor(kRed);
-    hBmass_l1l2_LT[ij]->SetLineWidth(2);
+    hBmass_l1notPFCand_l2PFCand[ij] = new TH1F(Form("Bmass_l1notPFCand_l2PFCand_%d", ij), "", 750, 0., 15.); // 75, 4.5, 6.);
+    hBmass_l1notPFCand_l2PFCand[ij]->Sumw2();
+    hBmass_l1notPFCand_l2PFCand[ij]->SetLineColor(kRed);
+    hBmass_l1notPFCand_l2PFCand[ij]->SetLineWidth(2);
     
-    hBmass_l2_LT[ij] = new TH1F(Form("Bmass_l2_LT_%d", ij), "", 750, 0., 15.); // 75, 4.5, 6.);
-    hBmass_l2_LT[ij]->Sumw2();
-    hBmass_l2_LT[ij]->SetLineColor(kRed);
-    hBmass_l2_LT[ij]->SetLineWidth(2);   
+    hBmass_l1LT_l2LT[ij] = new TH1F(Form("Bmass_l1LT_l2LT_%d", ij), "", 750, 0., 15.); // 75, 4.5, 6.);
+    hBmass_l1LT_l2LT[ij]->Sumw2();
+    hBmass_l1LT_l2LT[ij]->SetLineColor(kRed);
+    hBmass_l1LT_l2LT[ij]->SetLineWidth(2);
+
+    hBmass_l1LT_l2notLT[ij] = new TH1F(Form("Bmass_l1LT_l2notLT_%d", ij), "", 750, 0., 15.); // 75, 4.5, 6.);
+    hBmass_l1LT_l2notLT[ij]->Sumw2();
+    hBmass_l1LT_l2notLT[ij]->SetLineColor(kRed);
+    hBmass_l1LT_l2notLT[ij]->SetLineWidth(2);
+    
+    hBmass_l1notLT_l2LT[ij] = new TH1F(Form("Bmass_l1notLT_l2LT_%d", ij), "", 750, 0., 15.); // 75, 4.5, 6.);
+    hBmass_l1notLT_l2LT[ij]->Sumw2();
+    hBmass_l1notLT_l2LT[ij]->SetLineColor(kRed);
+    hBmass_l1notLT_l2LT[ij]->SetLineWidth(2);   
 
     hctxy[ij] = new TH1F(Form("hctxy_%d", ij), "", 1000, 0., 10.);
     hctxy[ij]->Sumw2();
@@ -744,12 +756,12 @@ int main(int argc, char **argv){
     int muon_tag_index_event = -1;
     int triplet_sel_index = -1;
     bool isllt = false;         
-    bool isl1l2_PFCand = false;
-    bool isl1_PFCand = false;
-    bool isl2_PFCand = false;
-    bool isl1l2_LT = false;
-    bool isl1_LT = false;
-    bool isl2_LT = false;
+    bool l1PFCand_l2PFCand = false;
+    bool l1PFCand_l2notPFCand = false;
+    bool l1notPFCand_l2PFCand = false;
+    bool l1LT_l2LT = false;
+    bool l1LT_l2notLT = false;
+    bool l1notLT_l2LT = false;
     bool l1PFLep_l2notPFLep = false;
     bool l1notPFLep_l2PFLep = false;
     bool l1notPFLep_l2notPFLep = false;
@@ -787,13 +799,13 @@ int main(int argc, char **argv){
 
 	isllt = (iL == 0) ? true : false;
 
-    isl1l2_PFCand = bool(BToKstll_lep1_isPFCand[triplet_sel_index] == 1 && BToKstll_lep2_isPFCand[triplet_sel_index]== 1);
-    isl1_PFCand = bool(BToKstll_lep1_isPFCand[triplet_sel_index]== 1);
-    isl2_PFCand = bool(BToKstll_lep2_isPFCand[triplet_sel_index]== 1);
+    l1PFCand_l2PFCand = bool(BToKstll_lep1_isPFCand[triplet_sel_index] == 1 && BToKstll_lep2_isPFCand[triplet_sel_index]== 1);
+    l1PFCand_l2notPFCand = bool(BToKstll_lep1_isPFCand[triplet_sel_index]== 1 && BToKstll_lep2_isPFCand[triplet_sel_index]!= 1);
+    l1notPFCand_l2PFCand = bool(BToKstll_lep1_isPFCand[triplet_sel_index]!= 1 && BToKstll_lep2_isPFCand[triplet_sel_index]== 1);
     
-    isl1l2_LT = bool(BToKstll_lep1_isLT[triplet_sel_index] == 1 && BToKstll_lep2_isLT[triplet_sel_index]== 1);
-    isl1_LT = bool(BToKstll_lep1_isLT[triplet_sel_index]== 1);
-    isl2_LT = bool(BToKstll_lep2_isLT[triplet_sel_index]== 1);
+    l1LT_l2LT = bool(BToKstll_lep1_isLT[triplet_sel_index] == 1 && BToKstll_lep2_isLT[triplet_sel_index]== 1);
+    l1LT_l2notLT = bool(BToKstll_lep1_isLT[triplet_sel_index]== 1 && BToKstll_lep2_isLT[triplet_sel_index]!= 1);
+    l1notLT_l2LT = bool(BToKstll_lep1_isLT[triplet_sel_index]!= 1 && BToKstll_lep2_isLT[triplet_sel_index]== 1);
     
     l1PFLep_l2notPFLep = bool(BToKstll_lep1_isPFLep[triplet_sel_index] == 1 && BToKstll_lep2_isPFLep[triplet_sel_index] != 1);
     l1notPFLep_l2PFLep = bool(BToKstll_lep1_isPFLep[triplet_sel_index] != 1 && BToKstll_lep2_isPFLep[triplet_sel_index] == 1);
@@ -919,6 +931,10 @@ int main(int argc, char **argv){
       hLep2pt[massBin]->Fill(BToKstll_lep2_pt[triplet_sel_index]);
       if(l1notPFLep_l2PFLep || l1notPFLep_l2notPFLep)hLep1pt_l1notPFLep[massBin]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
       if(l1PFLep_l2notPFLep || l1notPFLep_l2notPFLep)hLep2pt_l2notPFLep[massBin]->Fill(BToKstll_lep2_pt[triplet_sel_index]);
+      if(l1PFCand_l2notPFCand || l1PFCand_l2PFCand) hLep1pt_PFCand[massBin]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
+      if(l1notPFCand_l2PFCand || l1PFCand_l2PFCand) hLep2pt_PFCand[massBin]->Fill(BToKstll_lep2_pt[triplet_sel_index]);
+      if(l1LT_l2notLT || l1LT_l2LT) hLep1pt_LT[massBin]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
+      if(l1notLT_l2LT || l1LT_l2LT) hLep2pt_LT[massBin]->Fill(BToKstll_lep2_pt[triplet_sel_index]);
       if(std::abs(BToKstll_lep1_eta[triplet_sel_index]) < 1.47) hLep1pt_EB[massBin]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
       else hLep1pt_EE[massBin]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
       if(std::abs(BToKstll_lep2_eta[triplet_sel_index]) < 1.47) hLep2pt_EB[massBin]->Fill(BToKstll_lep2_pt[triplet_sel_index]);
@@ -926,24 +942,20 @@ int main(int argc, char **argv){
 
       hllRefitMass[massBin]->Fill(llInvRefitMass);
       hllRefitMass_vs_Bmass[massBin]->Fill(BToKstll_B_mass[triplet_sel_index], llInvRefitMass);
+      
       hBmass[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
       if(isllt) hBmass_llt[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
-      else hBmass_not_llt[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
+      else hBmass_not_llt[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);      
       if(l1PFLep_l2notPFLep) hBmass_l1PFLep_l2notPFLep[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
       if(l1notPFLep_l2PFLep) hBmass_l1notPFLep_l2PFLep[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
       if(l1notPFLep_l2notPFLep) hBmass_l1notPFLep_l2notPFLep[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
-      if(isl1l2_PFCand) hBmass_l1l2_PFCand[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
-      if(isl1_PFCand) hLep1pt_PFCand[massBin]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
-      if(isl2_PFCand){ 
-        hBmass_l2_PFCand[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
-        hLep2pt_PFCand[massBin]->Fill(BToKstll_lep2_pt[triplet_sel_index]);
-      }
-      if(isl1l2_LT) hBmass_l1l2_LT[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
-      if(isl1_LT) hLep1pt_LT[massBin]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
-      if(isl2_LT){
-        hBmass_l2_LT[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
-        hLep2pt_LT[massBin]->Fill(BToKstll_lep2_pt[triplet_sel_index]);
-      }
+      if(l1PFCand_l2PFCand) hBmass_l1PFCand_l2PFCand[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
+      if(l1PFCand_l2notPFCand) hBmass_l1PFCand_l2notPFCand[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
+      if(l1notPFCand_l2PFCand) hBmass_l1notPFCand_l2PFCand[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
+      if(l1LT_l2LT) hBmass_l1LT_l2LT[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]); 
+      if(l1LT_l2notLT) hBmass_l1LT_l2notLT[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
+      if(l1notLT_l2LT) hBmass_l1notLT_l2LT[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
+      
 
       BDTele1_vs_pTele1[massBin]->Fill(BToKstll_lep1_pt[triplet_sel_index], BToKstll_lep1_seedBDT_unbiased[triplet_sel_index]);
       BDTele2_vs_pTele2[massBin]->Fill(BToKstll_lep2_pt[triplet_sel_index], BToKstll_lep2_seedBDT_unbiased[triplet_sel_index]);
@@ -960,18 +972,12 @@ int main(int argc, char **argv){
     if(l1PFLep_l2notPFLep) hBmass_l1PFLep_l2notPFLep[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
     if(l1notPFLep_l2PFLep) hBmass_l1notPFLep_l2PFLep[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
     if(l1notPFLep_l2notPFLep) hBmass_l1notPFLep_l2notPFLep[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
-    if(isl1l2_PFCand) hBmass_l1l2_PFCand[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
-    if(isl1_PFCand) hLep1pt_PFCand[6]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
-    if(isl2_PFCand){
-        hBmass_l2_PFCand[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
-        hLep2pt_PFCand[6]->Fill(BToKstll_lep2_pt[triplet_sel_index]);
-    }
-    if(isl1l2_LT) hBmass_l1l2_LT[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
-    if(isl1_LT) hLep1pt_LT[6]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
-    if(isl2_LT){
-        hBmass_l2_LT[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
-        hLep2pt_LT[6]->Fill(BToKstll_lep2_pt[triplet_sel_index]);
-    }
+    if(l1PFCand_l2PFCand) hBmass_l1PFCand_l2PFCand[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
+    if(l1PFCand_l2notPFCand) hBmass_l1PFCand_l2notPFCand[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
+    if(l1notPFCand_l2PFCand) hBmass_l1notPFCand_l2PFCand[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
+    if(l1LT_l2LT) hBmass_l1LT_l2LT[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
+    if(l1LT_l2notLT) hBmass_l1LT_l2notLT[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
+    if(l1notLT_l2LT) hBmass_l1notLT_l2LT[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
 
     hAlpha[6]->Fill(BToKstll_B_cosAlpha[triplet_sel_index]);
     hCLVtx[6]->Fill(BToKstll_B_CL_vtx[triplet_sel_index]);
@@ -985,6 +991,10 @@ int main(int argc, char **argv){
     hLep2pt[6]->Fill(BToKstll_lep2_pt[triplet_sel_index]);
     if(l1notPFLep_l2PFLep || l1notPFLep_l2notPFLep)hLep1pt_l1notPFLep[6]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
     if(l1PFLep_l2notPFLep || l1notPFLep_l2notPFLep)hLep2pt_l2notPFLep[6]->Fill(BToKstll_lep2_pt[triplet_sel_index]);
+    if(l1PFCand_l2notPFCand || l1PFCand_l2PFCand) hLep1pt_PFCand[6]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
+    if(l1notPFCand_l2PFCand || l1PFCand_l2PFCand) hLep2pt_PFCand[6]->Fill(BToKstll_lep2_pt[triplet_sel_index]);
+    if(l1LT_l2notLT || l1LT_l2LT) hLep1pt_LT[6]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
+    if(l1notLT_l2LT || l1LT_l2LT) hLep2pt_LT[6]->Fill(BToKstll_lep2_pt[triplet_sel_index]);
     if(std::abs(BToKstll_lep1_eta[triplet_sel_index]) < 1.47) hLep1pt_EB[6]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
     else hLep1pt_EE[6]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
     if(std::abs(BToKstll_lep2_eta[triplet_sel_index]) < 1.47) hLep2pt_EB[6]->Fill(BToKstll_lep2_pt[triplet_sel_index]);
@@ -1042,10 +1052,12 @@ int main(int argc, char **argv){
     hBmass_l1notPFLep_l2PFLep[ij]->Write(hBmass_l1notPFLep_l2PFLep[ij]->GetName());
     hBmass_l1PFLep_l2notPFLep[ij]->Write(hBmass_l1PFLep_l2notPFLep[ij]->GetName());
     hBmass_l1notPFLep_l2notPFLep[ij]->Write(hBmass_l1notPFLep_l2notPFLep[ij]->GetName());
-    hBmass_l1l2_PFCand[ij]->Write(hBmass_l1l2_PFCand[ij]->GetName());
-    hBmass_l2_PFCand[ij]->Write(hBmass_l2_PFCand[ij]->GetName());
-    hBmass_l1l2_LT[ij]->Write(hBmass_l1l2_LT[ij]->GetName());
-    hBmass_l2_LT[ij]->Write(hBmass_l2_LT[ij]->GetName());
+    hBmass_l1PFCand_l2PFCand[ij]->Write(hBmass_l1PFCand_l2PFCand[ij]->GetName());
+    hBmass_l1PFCand_l2notPFCand[ij]->Write(hBmass_l1PFCand_l2notPFCand[ij]->GetName());
+    hBmass_l1notPFCand_l2PFCand[ij]->Write(hBmass_l1notPFCand_l2PFCand[ij]->GetName());
+    hBmass_l1LT_l2LT[ij]->Write(hBmass_l1LT_l2LT[ij]->GetName());
+    hBmass_l1LT_l2notLT[ij]->Write(hBmass_l1LT_l2notLT[ij]->GetName());
+    hBmass_l1notLT_l2LT[ij]->Write(hBmass_l1notLT_l2LT[ij]->GetName());
 
     BDTele1_vs_pTele1[ij]->Write(BDTele1_vs_pTele1[ij]->GetName());
     BDTele2_vs_pTele2[ij]->Write(BDTele2_vs_pTele2[ij]->GetName());

--- a/NtupleProducer/macro/analyzeCharged_fastDATA_Kstll.cpp
+++ b/NtupleProducer/macro/analyzeCharged_fastDATA_Kstll.cpp
@@ -795,9 +795,9 @@ int main(int argc, char **argv){
     isl1_LT = bool(BToKstll_lep1_isLT[triplet_sel_index]== 1);
     isl2_LT = bool(BToKstll_lep2_isLT[triplet_sel_index]== 1);
     
-    l1PFLep_l2notPFLep = bool(BToKstll_lep1_isPFCand[triplet_sel_index] == 1 && BToKstll_lep2_isPFCand[triplet_sel_index] != 1);
-    l1notPFLep_l2PFLep = bool(BToKstll_lep1_isPFCand[triplet_sel_index] != 1 && BToKstll_lep2_isPFCand[triplet_sel_index] == 1);
-    l1notPFLep_l2notPFLep = bool(BToKstll_lep1_isPFCand[triplet_sel_index] != 1 && BToKstll_lep2_isPFCand[triplet_sel_index] != 1);    
+    l1PFLep_l2notPFLep = bool(BToKstll_lep1_isPFLep[triplet_sel_index] == 1 && BToKstll_lep2_isPFLep[triplet_sel_index] != 1);
+    l1notPFLep_l2PFLep = bool(BToKstll_lep1_isPFLep[triplet_sel_index] != 1 && BToKstll_lep2_isPFLep[triplet_sel_index] == 1);
+    l1notPFLep_l2notPFLep = bool(BToKstll_lep1_isPFLep[triplet_sel_index] != 1 && BToKstll_lep2_isPFLep[triplet_sel_index] != 1);    
     
 	goodTripletFound = true;
 	break;

--- a/NtupleProducer/macro/analyzeCharged_fastDATA_Kstll.cpp
+++ b/NtupleProducer/macro/analyzeCharged_fastDATA_Kstll.cpp
@@ -521,8 +521,14 @@ int main(int argc, char **argv){
   TH1F* hKaonpt[7];
   TH1F* hLep1pt[7];
   TH1F* hLep2pt[7];
+  TH1F* hLep1pt_PFLep[7];
+  TH1F* hLep2pt_PFLep[7];
   TH1F* hLep1pt_l1notPFLep[7];
   TH1F* hLep2pt_l2notPFLep[7];
+  TH1F* hLep1pt_l1PFLep_l2notPFLep[7];
+  TH1F* hLep2pt_l1PFLep_l2notPFLep[7];
+  TH1F* hLep1pt_l1notPFLep_l2notPFLep[7];
+  TH1F* hLep2pt_l1notPFLep_l2notPFLep[7];  
   TH1F* hLep1pt_PFCand[7];
   TH1F* hLep2pt_PFCand[7];
   TH1F* hLep1pt_LT[7];
@@ -536,7 +542,6 @@ int main(int argc, char **argv){
   TH2F* hllRefitMass_vs_Bmass[7];
   TH1F* hBmass[7];
   TH1F* hBmass_llt[7];
-  TH1F* hBmass_not_llt[7];
   TH1F* hBmass_l1PFLep_l2notPFLep[7];
   TH1F* hBmass_l1notPFLep_l2PFLep[7];
   TH1F* hBmass_l1notPFLep_l2notPFLep[7];
@@ -591,11 +596,6 @@ int main(int argc, char **argv){
     hBmass_llt[ij]->Sumw2();
     hBmass_llt[ij]->SetLineColor(kRed);
     hBmass_llt[ij]->SetLineWidth(2);
-
-    hBmass_not_llt[ij] = new TH1F(Form("Bmass_not_llt_%d", ij), "", 750, 0., 15.); // 75, 4.5, 6.);
-    hBmass_not_llt[ij]->Sumw2();
-    hBmass_not_llt[ij]->SetLineColor(kRed);
-    hBmass_not_llt[ij]->SetLineWidth(2);
     
     hBmass_l1PFLep_l2notPFLep[ij] = new TH1F(Form("Bmass_l1PFLep_l2notPFLep_%d", ij), "", 750, 0., 15.); // 75, 4.5, 6.);
     hBmass_l1PFLep_l2notPFLep[ij]->Sumw2();
@@ -656,11 +656,26 @@ int main(int argc, char **argv){
     hLep1pt[ij]->Sumw2();
     hLep1pt[ij]->SetLineColor(kRed);
     hLep1pt[ij]->SetLineWidth(2);
+    
+    hLep1pt_PFLep[ij] = new TH1F(Form("hLep1pt_PFLep_%d", ij), "", 100, 0., 10.);
+    hLep1pt_PFLep[ij]->Sumw2();
+    hLep1pt_PFLep[ij]->SetLineColor(kRed);
+    hLep1pt_PFLep[ij]->SetLineWidth(2);
 
     hLep1pt_l1notPFLep[ij] = new TH1F(Form("hLep1pt_l1notPFLep_%d", ij), "", 100, 0., 10.);
     hLep1pt_l1notPFLep[ij]->Sumw2();
     hLep1pt_l1notPFLep[ij]->SetLineColor(kRed);
     hLep1pt_l1notPFLep[ij]->SetLineWidth(2);
+    
+    hLep1pt_l1PFLep_l2notPFLep[ij] = new TH1F(Form("hLep1pt_l1PFLep_l2notPFLep_%d", ij), "", 100, 0., 10.);
+    hLep1pt_l1PFLep_l2notPFLep[ij]->Sumw2();
+    hLep1pt_l1PFLep_l2notPFLep[ij]->SetLineColor(kRed);
+    hLep1pt_l1PFLep_l2notPFLep[ij]->SetLineWidth(2);
+    
+    hLep1pt_l1notPFLep_l2notPFLep[ij] = new TH1F(Form("hLep1pt_l1notPFLep_l2notPFLep_%d", ij), "", 100, 0., 10.);
+    hLep1pt_l1notPFLep_l2notPFLep[ij]->Sumw2();
+    hLep1pt_l1notPFLep_l2notPFLep[ij]->SetLineColor(kRed);
+    hLep1pt_l1notPFLep_l2notPFLep[ij]->SetLineWidth(2);    
     
     hLep1pt_PFCand[ij] = new TH1F(Form("hLep1pt_PFCand_%d", ij), "", 100, 0., 10.);
     hLep1pt_PFCand[ij]->Sumw2();
@@ -676,11 +691,26 @@ int main(int argc, char **argv){
     hLep2pt[ij]->Sumw2();
     hLep2pt[ij]->SetLineColor(kRed);
     hLep2pt[ij]->SetLineWidth(2);
+
+    hLep2pt_PFLep[ij] = new TH1F(Form("hLep2pt_PFLep_%d", ij), "", 100, 0., 10.);
+    hLep2pt_PFLep[ij]->Sumw2();
+    hLep2pt_PFLep[ij]->SetLineColor(kRed);
+    hLep2pt_PFLep[ij]->SetLineWidth(2);
     
     hLep2pt_l2notPFLep[ij] = new TH1F(Form("hLep2pt_l2notPFLep_%d", ij), "", 100, 0., 10.);
     hLep2pt_l2notPFLep[ij]->Sumw2();
     hLep2pt_l2notPFLep[ij]->SetLineColor(kRed);
     hLep2pt_l2notPFLep[ij]->SetLineWidth(2);    
+
+    hLep2pt_l1PFLep_l2notPFLep[ij] = new TH1F(Form("hLep2pt_l1PFLep_l2notPFLep_%d", ij), "", 100, 0., 10.);
+    hLep2pt_l1PFLep_l2notPFLep[ij]->Sumw2();
+    hLep2pt_l1PFLep_l2notPFLep[ij]->SetLineColor(kRed);
+    hLep2pt_l1PFLep_l2notPFLep[ij]->SetLineWidth(2);
+    
+    hLep2pt_l1notPFLep_l2notPFLep[ij] = new TH1F(Form("hLep2pt_l1notPFLep_l2notPFLep_%d", ij), "", 100, 0., 10.);
+    hLep2pt_l1notPFLep_l2notPFLep[ij]->Sumw2();
+    hLep2pt_l1notPFLep_l2notPFLep[ij]->SetLineColor(kRed);
+    hLep2pt_l1notPFLep_l2notPFLep[ij]->SetLineWidth(2);
     
     hLep2pt_PFCand[ij] = new TH1F(Form("hLep2pt_PFCand_%d", ij), "", 100, 0., 10.);
     hLep2pt_PFCand[ij]->Sumw2();
@@ -944,11 +974,22 @@ int main(int argc, char **argv){
       hllRefitMass_vs_Bmass[massBin]->Fill(BToKstll_B_mass[triplet_sel_index], llInvRefitMass);
       
       hBmass[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
-      if(isllt) hBmass_llt[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
-      else hBmass_not_llt[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);      
-      if(l1PFLep_l2notPFLep) hBmass_l1PFLep_l2notPFLep[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
+      if(isllt){ 
+          hBmass_llt[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
+          hLep1pt_PFLep[massBin]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
+          hLep2pt_PFLep[massBin]->Fill(BToKstll_lep2_pt[triplet_sel_index]);
+      }
+      if(l1PFLep_l2notPFLep){
+          hBmass_l1PFLep_l2notPFLep[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
+          hLep1pt_l1PFLep_l2notPFLep[massBin]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
+          hLep2pt_l1PFLep_l2notPFLep[massBin]->Fill(BToKstll_lep2_pt[triplet_sel_index]);
+      }
       if(l1notPFLep_l2PFLep) hBmass_l1notPFLep_l2PFLep[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
-      if(l1notPFLep_l2notPFLep) hBmass_l1notPFLep_l2notPFLep[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
+      if(l1notPFLep_l2notPFLep){
+          hBmass_l1notPFLep_l2notPFLep[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
+          hLep1pt_l1notPFLep_l2notPFLep[massBin]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
+          hLep2pt_l1notPFLep_l2notPFLep[massBin]->Fill(BToKstll_lep2_pt[triplet_sel_index]);
+      }
       if(l1PFCand_l2PFCand) hBmass_l1PFCand_l2PFCand[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
       if(l1PFCand_l2notPFCand) hBmass_l1PFCand_l2notPFCand[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
       if(l1notPFCand_l2PFCand) hBmass_l1notPFCand_l2PFCand[massBin]->Fill(BToKstll_B_mass[triplet_sel_index]);
@@ -967,11 +1008,22 @@ int main(int argc, char **argv){
     hllRefitMass[6]->Fill(llInvRefitMass);
     hllRefitMass_vs_Bmass[6]->Fill(BToKstll_B_mass[triplet_sel_index], llInvRefitMass);
     hBmass[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
-    if(isllt) hBmass_llt[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
-    else hBmass_not_llt[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
-    if(l1PFLep_l2notPFLep) hBmass_l1PFLep_l2notPFLep[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
+    if(isllt){
+        hBmass_llt[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
+        hLep1pt_PFLep[6]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
+        hLep2pt_PFLep[6]->Fill(BToKstll_lep2_pt[triplet_sel_index]);
+    }
+    if(l1PFLep_l2notPFLep){
+        hBmass_l1PFLep_l2notPFLep[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
+        hLep1pt_l1PFLep_l2notPFLep[6]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
+        hLep2pt_l1PFLep_l2notPFLep[6]->Fill(BToKstll_lep2_pt[triplet_sel_index]);        
+    }
     if(l1notPFLep_l2PFLep) hBmass_l1notPFLep_l2PFLep[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
-    if(l1notPFLep_l2notPFLep) hBmass_l1notPFLep_l2notPFLep[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
+    if(l1notPFLep_l2notPFLep){
+        hBmass_l1notPFLep_l2notPFLep[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
+        hLep1pt_l1notPFLep_l2notPFLep[6]->Fill(BToKstll_lep1_pt[triplet_sel_index]);
+        hLep2pt_l1notPFLep_l2notPFLep[6]->Fill(BToKstll_lep2_pt[triplet_sel_index]);         
+    }
     if(l1PFCand_l2PFCand) hBmass_l1PFCand_l2PFCand[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
     if(l1PFCand_l2notPFCand) hBmass_l1PFCand_l2notPFCand[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
     if(l1notPFCand_l2PFCand) hBmass_l1notPFCand_l2PFCand[6]->Fill(BToKstll_B_mass[triplet_sel_index]);
@@ -1029,11 +1081,17 @@ int main(int argc, char **argv){
     hctxy[ij]->Write(hctxy[ij]->GetName());
     hKaonpt[ij]->Write(hKaonpt[ij]->GetName());
     hLep1pt[ij]->Write(hLep1pt[ij]->GetName());
+    hLep1pt_PFLep[ij]->Write(hLep1pt_PFLep[ij]->GetName());
     hLep1pt_l1notPFLep[ij]->Write(hLep1pt_l1notPFLep[ij]->GetName());
+    hLep1pt_l1PFLep_l2notPFLep[ij]->Write(hLep1pt_l1PFLep_l2notPFLep[ij]->GetName());
+    hLep1pt_l1notPFLep_l2notPFLep[ij]->Write(hLep1pt_l1notPFLep_l2notPFLep[ij]->GetName());
     hLep1pt_PFCand[ij]->Write(hLep1pt_PFCand[ij]->GetName());
     hLep1pt_LT[ij]->Write(hLep1pt_LT[ij]->GetName());
     hLep2pt[ij]->Write(hLep2pt[ij]->GetName());
+    hLep2pt_PFLep[ij]->Write(hLep2pt_PFLep[ij]->GetName());
     hLep2pt_l2notPFLep[ij]->Write(hLep2pt_l2notPFLep[ij]->GetName());
+    hLep2pt_l1PFLep_l2notPFLep[ij]->Write(hLep2pt_l1PFLep_l2notPFLep[ij]->GetName());
+    hLep2pt_l1notPFLep_l2notPFLep[ij]->Write(hLep2pt_l1notPFLep_l2notPFLep[ij]->GetName());
     hLep2pt_PFCand[ij]->Write(hLep2pt_PFCand[ij]->GetName());
     hLep2pt_LT[ij]->Write(hLep2pt_LT[ij]->GetName());
     hLep1pt_EB[ij]->Write(hLep1pt_EB[ij]->GetName());
@@ -1048,7 +1106,6 @@ int main(int argc, char **argv){
     hllRefitMass_vs_Bmass[ij]->Write(hllRefitMass_vs_Bmass[ij]->GetName());
     hBmass[ij]->Write(hBmass[ij]->GetName());
     hBmass_llt[ij]->Write(hBmass_llt[ij]->GetName());
-    hBmass_not_llt[ij]->Write(hBmass_not_llt[ij]->GetName());
     hBmass_l1notPFLep_l2PFLep[ij]->Write(hBmass_l1notPFLep_l2PFLep[ij]->GetName());
     hBmass_l1PFLep_l2notPFLep[ij]->Write(hBmass_l1PFLep_l2notPFLep[ij]->GetName());
     hBmass_l1notPFLep_l2notPFLep[ij]->Write(hBmass_l1notPFLep_l2notPFLep[ij]->GetName());

--- a/NtupleProducer/macro/fitBmass_fromHistos.C
+++ b/NtupleProducer/macro/fitBmass_fromHistos.C
@@ -71,11 +71,17 @@ void fitBmass_fromHistos(int isEleFinalState, std::string inFile){
 
   TH1F* h_Bmass[7];
   TH1F* h_Bmass_llt[7];
-  TH1F* h_Bmass_not_llt[7];
+  TH1F* h_Bmass_l1notPFLep_l2PFLep[7];
+  TH1F* h_Bmass_l1PFLep_l2notPFLep[7];
+  TH1F* h_Bmass_l1notPFLep_l2notPFLep[7];
+  
   for(int ij=0; ij<7; ++ij){
-    h_Bmass[ij] = (TH1F*)inF->Get(Form("Bmass_%d", ij))->Clone(Form("h_Bmass_%d", ij));
+    
+    h_Bmass[ij] = (TH1F*)inF->Get(Form("Bmass_%d", ij))->Clone(Form("h_Bmass_%d", ij));    
     h_Bmass_llt[ij] = (TH1F*)inF->Get(Form("Bmass_llt_%d", ij))->Clone(Form("h_Bmass_llt_%d", ij));
-    h_Bmass_not_llt[ij] = (TH1F*)inF->Get(Form("Bmass_not_llt_%d", ij))->Clone(Form("h_Bmass_not_llt_%d", ij));
+    h_Bmass_l1notPFLep_l2PFLep[ij] = (TH1F*)inF->Get(Form("Bmass_l1notPFLep_l2PFLep_%d", ij))->Clone(Form("h_Bmass_l1notPFLep_l2PFLep_%d", ij));
+    h_Bmass_l1PFLep_l2notPFLep[ij] = (TH1F*)inF->Get(Form("Bmass_l1PFLep_l2notPFLep_%d", ij))->Clone(Form("h_Bmass_l1PFLep_l2notPFLep_%d", ij));
+    h_Bmass_l1notPFLep_l2notPFLep[ij] = (TH1F*)inF->Get(Form("Bmass_l1notPFLep_l2notPFLep_%d", ij))->Clone(Form("h_Bmass_l1notPFLep_l2notPFLep_%d", ij));
     //    h_Bmass[ij]->GetXaxis()->SetRangeUser(4.5, 6.);
   }//loop
 
@@ -118,7 +124,9 @@ void fitBmass_fromHistos(int isEleFinalState, std::string inFile){
     
     RooDataHist hBMass("hBMass", "hBMass", *w.var("x"), Import(*(h_Bmass[ij])));
     RooDataHist hBMass_llt("hBMass_llt", "hBMass_llt", *w.var("x"), Import(*(h_Bmass_llt[ij])));
-    RooDataHist hBMass_not_llt("hBMass_not_llt", "hBMass_not_llt", *w.var("x"), Import(*(h_Bmass_not_llt[ij])));
+    RooDataHist hBMass_l1notPFLep_l2PFLep("hBMass_l1notPFLep_l2PFLep", "hBMass_l1notPFLep_l2PFLep", *w.var("x"), Import(*(h_Bmass_l1notPFLep_l2PFLep[ij])));
+    RooDataHist hBMass_l1PFLep_l2notPFLep("hBMass_l1PFLep_l2notPFLep", "hBMass_l1PFLep_l2notPFLep", *w.var("x"), Import(*(h_Bmass_l1PFLep_l2notPFLep[ij])));
+    RooDataHist hBMass_l1notPFLep_l2notPFLep("hBMass_l1notPFLep_l2notPFLep", "hBMass_l1notPFLep_l2notPFLep", *w.var("x"), Import(*(h_Bmass_l1notPFLep_l2notPFLep[ij])));
     w.Print();
 
     RooFitResult * r = model->fitTo(hBMass, Minimizer("Minuit2"),Save(true));
@@ -138,9 +146,11 @@ void fitBmass_fromHistos(int isEleFinalState, std::string inFile){
     hBMass.plotOn(plot);
     model->plotOn(plot);
     model->plotOn(plot, Components("modelb"),LineStyle(kDashed));
-    model->plotOn(plot, Components("smodel"),LineColor(kRed));
-    hBMass_llt.plotOn(plot,LineColor(kGreen+2),MarkerColor(kGreen+2)) ;
-    hBMass_not_llt.plotOn(plot,LineColor(kViolet),MarkerColor(kViolet)) ;
+    model->plotOn(plot, Components("smodel"),LineColor(kOrange));
+    hBMass_llt.plotOn(plot,LineColor(kGreen+1),MarkerColor(kGreen+1)) ;
+    hBMass_l1notPFLep_l2PFLep.plotOn(plot,LineColor(kCyan+1),MarkerColor(kCyan+1)) ;
+    hBMass_l1PFLep_l2notPFLep.plotOn(plot,LineColor(kMagenta),MarkerColor(kMagenta)) ;
+    hBMass_l1notPFLep_l2notPFLep.plotOn(plot,LineColor(kRed),MarkerColor(kRed)) ;
     chi2[ij] = plot->chiSquare();
 
     RooRealVar* parS = (RooRealVar*) r->floatParsFinal().find("nsignal");
@@ -214,4 +224,4 @@ void fitBmass_fromHistos(int isEleFinalState, std::string inFile){
 	      << " chi2 = " << chi2[ij] << std::endl;
   }
 
-} 
+}  

--- a/NtupleProducer/macro/fitBmass_fromHistos.C
+++ b/NtupleProducer/macro/fitBmass_fromHistos.C
@@ -71,7 +71,6 @@ void fitBmass_fromHistos(int isEleFinalState, std::string inFile){
 
   TH1F* h_Bmass[7];
   TH1F* h_Bmass_llt[7];
-  TH1F* h_Bmass_l1notPFLep_l2PFLep[7];
   TH1F* h_Bmass_l1PFLep_l2notPFLep[7];
   TH1F* h_Bmass_l1notPFLep_l2notPFLep[7];
   
@@ -79,7 +78,6 @@ void fitBmass_fromHistos(int isEleFinalState, std::string inFile){
     
     h_Bmass[ij] = (TH1F*)inF->Get(Form("Bmass_%d", ij))->Clone(Form("h_Bmass_%d", ij));    
     h_Bmass_llt[ij] = (TH1F*)inF->Get(Form("Bmass_llt_%d", ij))->Clone(Form("h_Bmass_llt_%d", ij));
-    h_Bmass_l1notPFLep_l2PFLep[ij] = (TH1F*)inF->Get(Form("Bmass_l1notPFLep_l2PFLep_%d", ij))->Clone(Form("h_Bmass_l1notPFLep_l2PFLep_%d", ij));
     h_Bmass_l1PFLep_l2notPFLep[ij] = (TH1F*)inF->Get(Form("Bmass_l1PFLep_l2notPFLep_%d", ij))->Clone(Form("h_Bmass_l1PFLep_l2notPFLep_%d", ij));
     h_Bmass_l1notPFLep_l2notPFLep[ij] = (TH1F*)inF->Get(Form("Bmass_l1notPFLep_l2notPFLep_%d", ij))->Clone(Form("h_Bmass_l1notPFLep_l2notPFLep_%d", ij));
     //    h_Bmass[ij]->GetXaxis()->SetRangeUser(4.5, 6.);
@@ -124,7 +122,6 @@ void fitBmass_fromHistos(int isEleFinalState, std::string inFile){
     
     RooDataHist hBMass("hBMass", "hBMass", *w.var("x"), Import(*(h_Bmass[ij])));
     RooDataHist hBMass_llt("hBMass_llt", "hBMass_llt", *w.var("x"), Import(*(h_Bmass_llt[ij])));
-    RooDataHist hBMass_l1notPFLep_l2PFLep("hBMass_l1notPFLep_l2PFLep", "hBMass_l1notPFLep_l2PFLep", *w.var("x"), Import(*(h_Bmass_l1notPFLep_l2PFLep[ij])));
     RooDataHist hBMass_l1PFLep_l2notPFLep("hBMass_l1PFLep_l2notPFLep", "hBMass_l1PFLep_l2notPFLep", *w.var("x"), Import(*(h_Bmass_l1PFLep_l2notPFLep[ij])));
     RooDataHist hBMass_l1notPFLep_l2notPFLep("hBMass_l1notPFLep_l2notPFLep", "hBMass_l1notPFLep_l2notPFLep", *w.var("x"), Import(*(h_Bmass_l1notPFLep_l2notPFLep[ij])));
     w.Print();
@@ -148,7 +145,6 @@ void fitBmass_fromHistos(int isEleFinalState, std::string inFile){
     model->plotOn(plot, Components("modelb"),LineStyle(kDashed));
     model->plotOn(plot, Components("smodel"),LineColor(kOrange));
     hBMass_llt.plotOn(plot,LineColor(kGreen+1),MarkerColor(kGreen+1)) ;
-    hBMass_l1notPFLep_l2PFLep.plotOn(plot,LineColor(kCyan+1),MarkerColor(kCyan+1)) ;
     hBMass_l1PFLep_l2notPFLep.plotOn(plot,LineColor(kMagenta),MarkerColor(kMagenta)) ;
     hBMass_l1notPFLep_l2notPFLep.plotOn(plot,LineColor(kRed),MarkerColor(kRed)) ;
     chi2[ij] = plot->chiSquare();


### PR DESCRIPTION
Keep first priority for triplets with both leptons being PF Lep. 
Second priority is now given to triplets with one lepton being PFLep and the other lowPtEle (or track). 
Finally, triplets with both leptons being lowPtEle (or track) are considered.

Add new B-mass plots for triplets with lep1 = PFLep & lep2 != PFLep, lep1 != PFLep & lep2 = PFLep, and lep1 != PFLep & lep2 != PFLep